### PR TITLE
feat: Allow `PRAGMA foreign_keys` to be versioned through dmwmtt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ pubspec.lock
 
 coverage.json
 lcov.info
+**/coverage/test/
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pubspec.lock
 
 coverage.json
 lcov.info
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ late final db;
 void main() {
   sqlite3.open("database.db");
 
-  Sqlite3Database(db).migrate([
+  Sqlite3Database(() => db).migrate([
     Migration(
       name: "add users table",
       definedAt: DateTime.utc(2026, 4, 12, 11, 4),

--- a/packages/generic/README.md
+++ b/packages/generic/README.md
@@ -44,7 +44,7 @@ late final db;
 void main() {
   sqlite3.open("database.db");
 
-  Sqlite3Database(db).migrate([
+  Sqlite3Database((_) => db).migrate([
     Migration(
       name: "add users table",
       definedAt: DateTime.utc(2026, 4, 12, 11, 4),
@@ -133,7 +133,7 @@ drop table users;
   ),
 ];
 
-Sqlite3Database(db).migrate(migrations);
+Sqlite3Database((_) => db).migrate(migrations);
 ```
 
 Adapters export everything you need, so you can just run `pub add sqlite3_migrations_with_multiverse_time_travel` and you're good to go.

--- a/packages/generic/example/db_migrations_with_multiverse_time_travel_example.dart
+++ b/packages/generic/example/db_migrations_with_multiverse_time_travel_example.dart
@@ -1,6 +1,6 @@
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
 
 void main() {
-  var migration = Migration(definedAt: DateTime(2025, 3, 6), up: 'up', down: 'down');
+  var migration = SyncMigration<void, String>(definedAt: DateTime(2025, 3, 6), up: 'up', down: 'down');
   print('awesome: ${migration.definedAt}');
 }

--- a/packages/generic/lib/src/algorithm.dart
+++ b/packages/generic/lib/src/algorithm.dart
@@ -211,7 +211,7 @@ class SyncMigrator<D, T> {
           _db!.beginTransaction();
           _inTransaction = true;
         }
-        lastCommon.render(_db!.db);
+        lastCommon.initialize(_db!.db);
         _db!.performMigration(lastCommon.up);
       }
       _moveNextDefined();
@@ -281,7 +281,7 @@ class SyncMigrator<D, T> {
       }
       final migration = _defined!.current.copyWith(appliedAt: now);
       log.finer('|_ + migration ${migration.humanReadableId}');
-      migration.render(_db!.db);
+      migration.initialize(_db!.db);
       _db!.performMigration(migration.up);
       toApply.add(migration);
       _moveNextDefined();
@@ -438,7 +438,7 @@ class AsyncMigrator<D, T> {
           await _db!.beginTransaction();
           _inTransaction = true;
         }
-        lastCommon.render(_db!.db);
+        lastCommon.initialize(_db!.db);
         await _db!.performMigration(lastCommon.up);
       }
       _moveNextDefined();
@@ -495,7 +495,7 @@ class AsyncMigrator<D, T> {
       }
       final migration = _defined!.current.copyWith(appliedAt: now);
       log.finer('|_ + migration ${migration.humanReadableId}');
-      migration.render(_db!.db);
+      migration.initialize(_db!.db);
       await _db!.performMigration(migration.up);
       toApply.add(migration);
       _moveNextDefined();

--- a/packages/generic/lib/src/algorithm.dart
+++ b/packages/generic/lib/src/algorithm.dart
@@ -448,7 +448,7 @@ class AsyncMigrator<D, T> {
         }
         if (!lastCommon.hasInstructions) {
           log.finest('building instructions for migration ${lastCommon.humanReadableId}');
-          await lastCommon.buildInstructions(_db!.db);
+          await lastCommon.buildInstructions(await _db!.db);
         }
         log.finer('applying always-apply migration ${lastCommon.humanReadableId}');
         await _db!.executeInstructions(lastCommon.up);
@@ -509,7 +509,7 @@ class AsyncMigrator<D, T> {
       log.finer('|_ - migration ${migration.humanReadableId}');
       if (!migration.hasInstructions) {
         log.finer('    [building instructions]');
-        await migration.buildInstructions(_db!.db);
+        await migration.buildInstructions(await _db!.db);
       }
       migration = migration.copyWith(appliedAt: now);
       await _db!.executeInstructions(migration.up);

--- a/packages/generic/lib/src/algorithm.dart
+++ b/packages/generic/lib/src/algorithm.dart
@@ -211,7 +211,11 @@ class SyncMigrator<D, T> {
           _db!.beginTransaction();
           _inTransaction = true;
         }
-        lastCommon.buildInstructions(_db!.db);
+        if (!lastCommon.hasInstructions) {
+          log.finest('building instructions for migration ${lastCommon.humanReadableId}');
+          lastCommon.buildInstructions(_db!.db);
+        }
+        log.finer('applying always-apply migration ${lastCommon.humanReadableId}');
         _db!.executeInstructions(lastCommon.up);
       }
       _moveNextDefined();
@@ -279,9 +283,13 @@ class SyncMigrator<D, T> {
         _db!.beginTransaction();
         _inTransaction = true;
       }
-      final migration = _defined!.current.copyWith(appliedAt: now);
-      log.finer('|_ + migration ${migration.humanReadableId}');
-      migration.buildInstructions(_db!.db);
+      var migration = _defined!.current;
+      log.finer('|_ - migration ${migration.humanReadableId}');
+      if (!migration.hasInstructions) {
+        log.finer('    [building instructions]');
+        migration.buildInstructions(_db!.db);
+      }
+      migration = migration.copyWith(appliedAt: now);
       _db!.executeInstructions(migration.up);
       toApply.add(migration);
       _moveNextDefined();
@@ -438,7 +446,11 @@ class AsyncMigrator<D, T> {
           await _db!.beginTransaction();
           _inTransaction = true;
         }
-        lastCommon.buildInstructions(_db!.db);
+        if (!lastCommon.hasInstructions) {
+          log.finest('building instructions for migration ${lastCommon.humanReadableId}');
+          await lastCommon.buildInstructions(_db!.db);
+        }
+        log.finer('applying always-apply migration ${lastCommon.humanReadableId}');
         await _db!.executeInstructions(lastCommon.up);
       }
       _moveNextDefined();
@@ -493,9 +505,13 @@ class AsyncMigrator<D, T> {
         await _db!.beginTransaction();
         _inTransaction = true;
       }
-      final migration = _defined!.current.copyWith(appliedAt: now);
-      log.finer('|_ + migration ${migration.humanReadableId}');
-      migration.buildInstructions(_db!.db);
+      var migration = _defined!.current;
+      log.finer('|_ - migration ${migration.humanReadableId}');
+      if (!migration.hasInstructions) {
+        log.finer('    [building instructions]');
+        await migration.buildInstructions(_db!.db);
+      }
+      migration = migration.copyWith(appliedAt: now);
       await _db!.executeInstructions(migration.up);
       toApply.add(migration);
       _moveNextDefined();

--- a/packages/generic/lib/src/algorithm.dart
+++ b/packages/generic/lib/src/algorithm.dart
@@ -207,6 +207,7 @@ class SyncMigrator<T> {
       lastCommon = _defined!.current;
       if (lastCommon.alwaysApply) {
         if (!_inTransaction) {
+          log.finer('beginning transaction...');
           _db!.beginTransaction();
           _inTransaction = true;
         }
@@ -244,6 +245,7 @@ class SyncMigrator<T> {
     final toRollback = [for (; _hasApplied; _moveNextApplied()) _applied!.current].reversed.toList();
 
     if (!_inTransaction && toRollback.isNotEmpty) {
+      log.finer('beginning transaction...');
       _db!.beginTransaction();
       _inTransaction = true;
     }
@@ -272,6 +274,7 @@ class SyncMigrator<T> {
 
     while (_hasDefined) {
       if (!_inTransaction) {
+        log.finer('beginning transaction...');
         _db!.beginTransaction();
         _inTransaction = true;
       }
@@ -429,6 +432,7 @@ class AsyncMigrator<T> {
       lastCommon = _defined!.current;
       if (lastCommon.alwaysApply) {
         if (!_inTransaction) {
+          log.finer('beginning transaction...');
           await _db!.beginTransaction();
           _inTransaction = true;
         }
@@ -460,6 +464,7 @@ class AsyncMigrator<T> {
     final toRollback = [for (; _hasApplied; await _moveNextApplied()) _applied!.current].reversed.toList();
 
     if (!_inTransaction && toRollback.isNotEmpty) {
+      log.finer('beginning transaction...');
       await _db!.beginTransaction();
       _inTransaction = true;
     }
@@ -481,6 +486,7 @@ class AsyncMigrator<T> {
     final now = DateTime.now().toUtc();
     while (_hasDefined) {
       if (!_inTransaction) {
+        log.finer('beginning transaction...');
         await _db!.beginTransaction();
         _inTransaction = true;
       }

--- a/packages/generic/lib/src/algorithm.dart
+++ b/packages/generic/lib/src/algorithm.dart
@@ -211,7 +211,7 @@ class SyncMigrator<D, T> {
           _db!.beginTransaction();
           _inTransaction = true;
         }
-        lastCommon.initialize(_db!.db);
+        lastCommon.buildInstructions(_db!.db);
         _db!.performMigration(lastCommon.up);
       }
       _moveNextDefined();
@@ -281,7 +281,7 @@ class SyncMigrator<D, T> {
       }
       final migration = _defined!.current.copyWith(appliedAt: now);
       log.finer('|_ + migration ${migration.humanReadableId}');
-      migration.initialize(_db!.db);
+      migration.buildInstructions(_db!.db);
       _db!.performMigration(migration.up);
       toApply.add(migration);
       _moveNextDefined();
@@ -438,7 +438,7 @@ class AsyncMigrator<D, T> {
           await _db!.beginTransaction();
           _inTransaction = true;
         }
-        lastCommon.initialize(_db!.db);
+        lastCommon.buildInstructions(_db!.db);
         await _db!.performMigration(lastCommon.up);
       }
       _moveNextDefined();
@@ -495,7 +495,7 @@ class AsyncMigrator<D, T> {
       }
       final migration = _defined!.current.copyWith(appliedAt: now);
       log.finer('|_ + migration ${migration.humanReadableId}');
-      migration.initialize(_db!.db);
+      migration.buildInstructions(_db!.db);
       await _db!.performMigration(migration.up);
       toApply.add(migration);
       _moveNextDefined();

--- a/packages/generic/lib/src/algorithm.dart
+++ b/packages/generic/lib/src/algorithm.dart
@@ -7,18 +7,18 @@ import 'database.dart';
 import 'migration.dart';
 
 /// An extension on [SyncDatabase] that adds a [migrate] method.
-extension SyncMigrateExt<T> on SyncDatabase<T> {
+extension SyncMigrateExt<D, T> on SyncDatabase<D, T> {
   /// Migrates the database using the given [migrations].
-  void migrate(List<Migration<T>> migrations) {
-    SyncMigrator<T>()(db: this, defined: migrations.iterator);
+  void migrate(List<SyncMigration<D, T>> migrations) {
+    SyncMigrator<D, T>()(db: this, defined: migrations.iterator);
   }
 }
 
 /// An extension on [AsyncDatabase] that adds a [migrate] method.
-extension AsyncMigrateExt<T> on AsyncDatabase<T> {
+extension AsyncMigrateExt<D, T> on AsyncDatabase<D, T> {
   /// Migrates the database using the given [migrations].
-  Future<void> migrate(List<Migration<T>> migrations) {
-    return AsyncMigrator<T>()(db: this, defined: migrations.iterator);
+  Future<void> migrate(List<AsyncMigration<D, T>> migrations) {
+    return AsyncMigrator<D, T>()(db: this, defined: migrations.iterator);
   }
 }
 
@@ -29,7 +29,7 @@ extension AsyncMigrateExt<T> on AsyncDatabase<T> {
 // Unfortunatly this ended up being an object instead of a function
 // but this made it easier to test
 /// {@endtemplate}
-class SyncMigrator<T> {
+class SyncMigrator<D, T> {
   /// Creates a new [SyncMigrator] with an optional [logger].
   ///
   /// {@template dmwmt.migrator.new}
@@ -51,17 +51,17 @@ class SyncMigrator<T> {
   /// {@endtemplate}
   final Logger log;
 
-  SyncDatabase<T>? _db;
+  SyncDatabase<D, T>? _db;
 
   /// {@template dmwmt.migrator._defined}
   /// The migrations that are defined in code.
   /// {@endtemplate}
-  Iterator<Migration<T>>? _defined;
+  Iterator<SyncMigration<D, T>>? _defined;
 
   /// {@template dmwmt.migrator._applied}
   /// The migrations that have been applied to the database.
   /// {@endtemplate}
-  Iterator<Migration<T>>? _applied;
+  Iterator<SyncMigration<D, T>>? _applied;
 
   /// {@template dmwmt.migrator._hasDefined}
   /// Whether there are any [_defined] migrations left to apply.
@@ -82,14 +82,14 @@ class SyncMigrator<T> {
   ///
   /// Used to ensure that migrations are being iterated in the correct order.
   /// {@endtemplate}
-  Migration<T>? _previousDefined;
+  SyncMigration<D, T>? _previousDefined;
 
   /// {@template dmwmt.migrator._previousApplied}
   /// The previous migration obtained from [_applied] before calling [_applied.moveNext].
   ///
   /// Used to ensure that migrations are being iterated in the correct order.
   /// {@endtemplate}
-  Migration<T>? _previousApplied;
+  SyncMigration<D, T>? _previousApplied;
 
   /// {@template dmwmt.migrator._inTransaction}
   /// Whether the migrator has started a transaction on the [_db].
@@ -127,7 +127,7 @@ class SyncMigrator<T> {
   /// Throws a [StateError] if the [Migration]s in [defined] are not in ascending order.
   /// Throws a [StateError] the [Migration]s obtained from the db are not in ascending order.
   /// {@endtemplate}
-  void call({required SyncDatabase<T> db, required Iterator<Migration<T>> defined}) {
+  void call({required SyncDatabase<D, T> db, required Iterator<SyncMigration<D, T>> defined}) {
     initialize(db, defined);
     // [_defined] and [_applied] are moved to the first migration
 
@@ -175,7 +175,7 @@ class SyncMigrator<T> {
   /// Throws a [ConcurrentModificationError] if the migrator is already [working].
   /// {@endtemplate}
   @visibleForTesting
-  void initialize(SyncDatabase<T> db, Iterator<Migration<T>> defined) {
+  void initialize(SyncDatabase<D, T> db, Iterator<SyncMigration<D, T>> defined) {
     log.finer('initializing migrator...');
 
     _db = db;
@@ -200,9 +200,9 @@ class SyncMigrator<T> {
   /// Any common migration that has [Migration.alwaysApply] set to `true` will be applied to the database.
   /// {@endtemplate}
   @visibleForTesting
-  Migration<T>? findLastCommonMigration() {
+  Migration<D, T>? findLastCommonMigration() {
     log.finer('finding last common migration...');
-    Migration<T>? lastCommon;
+    Migration<D, T>? lastCommon;
     while (_hasDefined && _hasApplied && _defined!.current == _applied!.current) {
       lastCommon = _defined!.current;
       if (lastCommon.alwaysApply) {
@@ -211,6 +211,7 @@ class SyncMigrator<T> {
           _db!.beginTransaction();
           _inTransaction = true;
         }
+        lastCommon.render(_db!.db);
         _db!.performMigration(lastCommon.up);
       }
       _moveNextDefined();
@@ -269,7 +270,7 @@ class SyncMigrator<T> {
   void applyRemainingDefinedMigrations() {
     log.fine('applying all remaining defined migrations');
 
-    final toApply = List<Migration<T>>.empty(growable: true);
+    final toApply = List<SyncMigration<D, T>>.empty(growable: true);
     final now = DateTime.now().toUtc();
 
     while (_hasDefined) {
@@ -280,6 +281,7 @@ class SyncMigrator<T> {
       }
       final migration = _defined!.current.copyWith(appliedAt: now);
       log.finer('|_ + migration ${migration.humanReadableId}');
+      migration.render(_db!.db);
       _db!.performMigration(migration.up);
       toApply.add(migration);
       _moveNextDefined();
@@ -305,7 +307,7 @@ class SyncMigrator<T> {
 }
 
 /// {@macro dmwmt.migrator}
-class AsyncMigrator<T> {
+class AsyncMigrator<D, T> {
   /// Creates a new [AsyncMigrator] with an optional [logger].
   ///
   /// {@macro dmwmt.migrator.new}
@@ -318,7 +320,7 @@ class AsyncMigrator<T> {
   /// {@macro dmwmt.migrator.log}
   final Logger log;
 
-  AsyncDatabase<T>? _db;
+  AsyncDatabase<D, T>? _db;
 
   /// Flag to check if the migrator is already working.
   ///
@@ -326,10 +328,10 @@ class AsyncMigrator<T> {
   bool get working => _db != null;
 
   /// {@macro dmwmt.migrator._defined}
-  Iterator<Migration<T>>? _defined;
+  Iterator<AsyncMigration<D, T>>? _defined;
 
   /// {@macro dmwmt.migrator._applied}
-  StreamIterator<Migration<T>>? _applied;
+  StreamIterator<AsyncMigration<D, T>>? _applied;
 
   /// {@macro dmwmt.migrator._hasDefined}
   bool _hasDefined;
@@ -338,10 +340,10 @@ class AsyncMigrator<T> {
   bool _hasApplied;
 
   /// {@macro dmwmt.migrator._previousDefined}
-  Migration<T>? _previousDefined;
+  AsyncMigration<D, T>? _previousDefined;
 
   /// {@macro dmwmt.migrator._previousApplied}
-  Migration<T>? _previousApplied;
+  AsyncMigration<D, T>? _previousApplied;
 
   /// {@macro dmwmt.migrator._inTransaction}
   bool _inTransaction;
@@ -369,7 +371,7 @@ class AsyncMigrator<T> {
   /// {@macro dmwmt.migrator.call}
   /// Throws a [ConcurrentModificationError] if the migrator is already [working].
   /// To prevent this, check [working] before calling this method.
-  Future<void> call({required AsyncDatabase<T> db, required Iterator<Migration<T>> defined}) async {
+  Future<void> call({required AsyncDatabase<D, T> db, required Iterator<AsyncMigration<D, T>> defined}) async {
     if (working) throw ConcurrentModificationError(this);
 
     await initialize(db, defined);
@@ -406,7 +408,7 @@ class AsyncMigrator<T> {
 
   /// {@macro dmwmt.migrator.initialize}
   @visibleForTesting
-  Future<void> initialize(AsyncDatabase<T> db, Iterator<Migration<T>> defined) async {
+  Future<void> initialize(AsyncDatabase<D, T> db, Iterator<AsyncMigration<D, T>> defined) async {
     log.finer('initializing migrator...');
 
     _db = db;
@@ -425,9 +427,9 @@ class AsyncMigrator<T> {
 
   /// {@macro dmwmt.migrator.findLastCommonMigration}
   @visibleForTesting
-  Future<Migration<T>?> findLastCommonMigration() async {
+  Future<AsyncMigration<D, T>?> findLastCommonMigration() async {
     log.finer('finding last common migration...');
-    Migration<T>? lastCommon;
+    AsyncMigration<D, T>? lastCommon;
     while (_hasDefined && _hasApplied && _defined!.current == _applied!.current) {
       lastCommon = _defined!.current;
       if (lastCommon.alwaysApply) {
@@ -436,6 +438,7 @@ class AsyncMigrator<T> {
           await _db!.beginTransaction();
           _inTransaction = true;
         }
+        lastCommon.render(_db!.db);
         await _db!.performMigration(lastCommon.up);
       }
       _moveNextDefined();
@@ -482,7 +485,7 @@ class AsyncMigrator<T> {
   Future<void> applyRemainingDefinedMigrations() async {
     log.fine('applying all remaining defined migrations');
 
-    final toApply = List<Migration<T>>.empty(growable: true);
+    final toApply = List<AsyncMigration<D, T>>.empty(growable: true);
     final now = DateTime.now().toUtc();
     while (_hasDefined) {
       if (!_inTransaction) {
@@ -492,6 +495,7 @@ class AsyncMigrator<T> {
       }
       final migration = _defined!.current.copyWith(appliedAt: now);
       log.finer('|_ + migration ${migration.humanReadableId}');
+      migration.render(_db!.db);
       await _db!.performMigration(migration.up);
       toApply.add(migration);
       _moveNextDefined();

--- a/packages/generic/lib/src/algorithm.dart
+++ b/packages/generic/lib/src/algorithm.dart
@@ -212,7 +212,7 @@ class SyncMigrator<D, T> {
           _inTransaction = true;
         }
         lastCommon.buildInstructions(_db!.db);
-        _db!.performMigration(lastCommon.up);
+        _db!.executeInstructions(lastCommon.up);
       }
       _moveNextDefined();
       _moveNextApplied();
@@ -253,7 +253,7 @@ class SyncMigrator<D, T> {
 
     for (final migration in toRollback) {
       log.finer('|_ - migration ${migration.humanReadableId}');
-      _db!.performMigration(migration.down);
+      _db!.executeInstructions(migration.down);
     }
     log.finest('updating applied migrations database table...');
     _db!.removeMigrations(toRollback);
@@ -282,7 +282,7 @@ class SyncMigrator<D, T> {
       final migration = _defined!.current.copyWith(appliedAt: now);
       log.finer('|_ + migration ${migration.humanReadableId}');
       migration.buildInstructions(_db!.db);
-      _db!.performMigration(migration.up);
+      _db!.executeInstructions(migration.up);
       toApply.add(migration);
       _moveNextDefined();
     }
@@ -439,7 +439,7 @@ class AsyncMigrator<D, T> {
           _inTransaction = true;
         }
         lastCommon.buildInstructions(_db!.db);
-        await _db!.performMigration(lastCommon.up);
+        await _db!.executeInstructions(lastCommon.up);
       }
       _moveNextDefined();
       await _moveNextApplied();
@@ -474,7 +474,7 @@ class AsyncMigrator<D, T> {
 
     for (final migration in toRollback) {
       log.finer('|_ - migration ${migration.humanReadableId}');
-      await _db!.performMigration(migration.down);
+      await _db!.executeInstructions(migration.down);
     }
     log.finest('updating applied migrations database table...');
     await _db!.removeMigrations(toRollback);
@@ -496,7 +496,7 @@ class AsyncMigrator<D, T> {
       final migration = _defined!.current.copyWith(appliedAt: now);
       log.finer('|_ + migration ${migration.humanReadableId}');
       migration.buildInstructions(_db!.db);
-      await _db!.performMigration(migration.up);
+      await _db!.executeInstructions(migration.up);
       toApply.add(migration);
       _moveNextDefined();
     }

--- a/packages/generic/lib/src/database.dart
+++ b/packages/generic/lib/src/database.dart
@@ -4,9 +4,9 @@ import 'migration.dart';
 
 /// {@template dmwmt.database}
 /// A database that can store and apply migrations.
-/// 
+///
 /// Implementations of this class should wrap a database library.
-/// 
+///
 /// [Db] is the type of the wrapped database,
 /// and [Serial] is the type of the migration instructions used by the database.
 /// {@endtemplate}

--- a/packages/generic/lib/src/database.dart
+++ b/packages/generic/lib/src/database.dart
@@ -9,7 +9,7 @@ import 'migration.dart';
 ///
 /// Implementations of this class should wrap a database library.
 /// {@endtemplate}
-abstract interface class MaybeAsyncDatabase<T> {
+abstract interface class MaybeAsyncDatabase<D, T> {
   /// {@template dmwmt.database.initializeMigrationsTable}
   /// Creates a table in the database that can store migrations.
   /// {@endtemplate}
@@ -30,17 +30,19 @@ abstract interface class MaybeAsyncDatabase<T> {
   /// {@template dmwmt.database.storeMigrations}
   /// Writes a migration to the database.
   /// {@endtemplate}
-  FutureOr<void> storeMigrations(List<Migration<T>> migrations);
+  FutureOr<void> storeMigrations(covariant List<Migration<D, T>> migrations);
 
   /// {@template dmwmt.database.removeMigrations}
   /// Removes a migration from the database.
   /// {@endtemplate}
-  FutureOr<void> removeMigrations(List<Migration<T>> migrations);
+  FutureOr<void> removeMigrations(covariant List<Migration<D, T>> migrations);
+
+  /// The wrapped database
+  D get db;
 
   /// {@template dmwmt.database.performMigration}
   /// Applies a migration to the database.
   /// {@endtemplate}
-
   FutureOr<void> performMigration(T migration);
 
   /// {@template dmwmt.database.beginTransaction}
@@ -62,7 +64,7 @@ abstract interface class MaybeAsyncDatabase<T> {
 /// {@macro dmwmt.database}
 ///
 /// This is used for synchronous databases. For asynchronous databases, use [AsyncDatabase].
-abstract interface class SyncDatabase<T> implements MaybeAsyncDatabase<T> {
+abstract interface class SyncDatabase<D, T> implements MaybeAsyncDatabase<D, T> {
   @override
   void initializeMigrationsTable();
 
@@ -70,13 +72,13 @@ abstract interface class SyncDatabase<T> implements MaybeAsyncDatabase<T> {
   bool isMigrationsTableInitialized();
 
   @override
-  Iterator<Migration<T>> retrieveAllMigrations();
+  Iterator<SyncMigration<D, T>> retrieveAllMigrations();
 
   @override
-  void storeMigrations(List<Migration<T>> migrations);
+  void storeMigrations(List<SyncMigration<D, T>> migrations);
 
   @override
-  void removeMigrations(List<Migration<T>> migrations);
+  void removeMigrations(List<SyncMigration<D, T>> migrations);
 
   @override
   void performMigration(T migration);
@@ -94,7 +96,7 @@ abstract interface class SyncDatabase<T> implements MaybeAsyncDatabase<T> {
 /// {@macro dmwmt.database}
 ///
 /// This is used for asynchronous databases. For synchronous databases, use [SyncDatabase].
-abstract interface class AsyncDatabase<T> implements MaybeAsyncDatabase<T> {
+abstract interface class AsyncDatabase<D, T> implements MaybeAsyncDatabase<D, T> {
   @override
-  Stream<Migration<T>> retrieveAllMigrations();
+  Stream<AsyncMigration<D, T>> retrieveAllMigrations();
 }

--- a/packages/generic/lib/src/database.dart
+++ b/packages/generic/lib/src/database.dart
@@ -39,7 +39,7 @@ abstract interface class MaybeAsyncDatabase<Db, Serial> {
   FutureOr<void> removeMigrations(covariant List<Migration<Db, Serial>> migrations);
 
   /// The wrapped database
-  Db get db;
+  FutureOr<Db> get db;
 
   /// {@template dmwmt.database.performMigration}
   /// Applies a migration to the database.
@@ -77,6 +77,9 @@ abstract interface class SyncDatabase<D, T> implements MaybeAsyncDatabase<D, T> 
 
   @override
   void storeMigrations(List<SyncMigration<D, T>> migrations);
+
+  @override
+  D get db;
 
   @override
   void removeMigrations(List<SyncMigration<D, T>> migrations);

--- a/packages/generic/lib/src/database.dart
+++ b/packages/generic/lib/src/database.dart
@@ -4,12 +4,13 @@ import 'migration.dart';
 
 /// {@template dmwmt.database}
 /// A database that can store and apply migrations.
-///
-/// The type parameter [T] is the type of the [Migration].
-///
+/// 
 /// Implementations of this class should wrap a database library.
+/// 
+/// [Db] is the type of the wrapped database,
+/// and [Serial] is the type of the migration instructions used by the database.
 /// {@endtemplate}
-abstract interface class MaybeAsyncDatabase<D, T> {
+abstract interface class MaybeAsyncDatabase<Db, Serial> {
   /// {@template dmwmt.database.initializeMigrationsTable}
   /// Creates a table in the database that can store migrations.
   /// {@endtemplate}
@@ -30,20 +31,20 @@ abstract interface class MaybeAsyncDatabase<D, T> {
   /// {@template dmwmt.database.storeMigrations}
   /// Writes a migration to the database.
   /// {@endtemplate}
-  FutureOr<void> storeMigrations(covariant List<Migration<D, T>> migrations);
+  FutureOr<void> storeMigrations(covariant List<Migration<Db, Serial>> migrations);
 
   /// {@template dmwmt.database.removeMigrations}
   /// Removes a migration from the database.
   /// {@endtemplate}
-  FutureOr<void> removeMigrations(covariant List<Migration<D, T>> migrations);
+  FutureOr<void> removeMigrations(covariant List<Migration<Db, Serial>> migrations);
 
   /// The wrapped database
-  D get db;
+  Db get db;
 
   /// {@template dmwmt.database.performMigration}
   /// Applies a migration to the database.
   /// {@endtemplate}
-  FutureOr<void> performMigration(T migration);
+  FutureOr<void> executeInstructions(Serial instructions);
 
   /// {@template dmwmt.database.beginTransaction}
   /// Starts a transaction.
@@ -81,7 +82,7 @@ abstract interface class SyncDatabase<D, T> implements MaybeAsyncDatabase<D, T> 
   void removeMigrations(List<SyncMigration<D, T>> migrations);
 
   @override
-  void performMigration(T migration);
+  void executeInstructions(T instructions);
 
   @override
   void beginTransaction();

--- a/packages/generic/lib/src/migration.dart
+++ b/packages/generic/lib/src/migration.dart
@@ -1,19 +1,45 @@
 import 'dart:async';
 
-//// {@template dmwmt.migration}
+import 'package:meta/meta.dart';
+
+/// An error that is thrown trying to access [Migration.up] or [Migration.down]
+/// when the migration is not [Migration.initialized].
+class UninitializedMigrationError extends StateError {
+  /// Creates an error that is thrown when a migration is not yet initialized.
+  UninitializedMigrationError(this.migration)
+      : super("${migration.humanReadableId} is not initialized. Call initialize() before accessing up or down.");
+
+  /// The migration that was not initialized.
+  final Migration<dynamic, dynamic> migration;
+}
+
+/// An error that is thrown when trying to initialize a migration that is already initialized.
+class AlreadyInitializedMigrationError extends StateError {
+  /// Creates an error that is thrown when trying to initialize a migration that is already initialized.
+  AlreadyInitializedMigrationError(this.migration)
+      : super("${migration.humanReadableId} is already initialized."
+            " Call initialize() only once, or check if the migration is already initialized using the 'initialized' property.");
+
+  /// The migration that was already initialized.
+  final Migration<dynamic, dynamic> migration;
+}
+
+/// {@template dmwmt.migration}
 /// A change to the database that can be applied and rolled back.
 ///
 /// A migration is implemented as a simple data class that uses [definedAt] as the primary key.
 ///
 /// Migrations have to be serialized and deserialized preserving atleast [definedAt] and [down]
 /// to be able to make [SyncMigrator] work.
-/// {endtemplate}
+/// {@endtemplate}
 sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
+  /// {@template dmwmt.migration.anon}
   /// Creates a new migration data class instance.
   ///
   /// Make sure that [definedAt] is unique for each migration and represents the time the code was edited.
   ///
   /// Throws an [ArgumentError] if [definedAt] is not in UTC.
+  /// {@endtemplate}
   Migration({
     required DateTime definedAt,
     this.name,
@@ -36,9 +62,27 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
         ),
         _down = down,
         _up = up,
-        _rendered = true,
+        _initialized = true,
         _renderer = null;
 
+  /// {@template dmwmt.migration.deferred}
+  /// Creates a new migration data class instance that is not yet initialized.
+  ///
+  /// This is useful when the action that the migration performs
+  /// depends on the database state at the moment the migration is applied.
+  ///
+  /// For example it can be shorter when altering a SQLite table,
+  /// to query the current SQL layout via sqlite_master and then
+  /// manipulate the SQL string, than to copy paste the entire
+  /// creation including all already made alterations again.
+  ///
+  /// When using this constructor, you must call [initialize] before accessing [up] or [down].
+  ///
+  /// When [initialize] is called, both [up] and [down] will be set.
+  /// This means effectively that a migration can be deferred
+  /// in the app code, but when it is stored in the database,
+  /// so that it can be rolled back, it will have been initialized.
+  /// {@endtemplate}
   Migration.deferred({
     required DateTime definedAt,
     this.name,
@@ -59,7 +103,7 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
           isUtc: true,
         ),
         _renderer = renderer,
-        _rendered = false;
+        _initialized = false;
 
   /// The identity of the migration.
   ///
@@ -90,12 +134,36 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
   /// but also may be incompatible with some states of the database during the migration.
   final bool alwaysApply;
 
-  bool _rendered;
-  bool get rendered => _rendered;
+  bool _initialized;
+
+  /// Whether this migration has been [initialize]d.
+  ///
+  /// When `true`, [up] and [down] are guaranteed to be set
+  /// and can be accessed without throwing an [UninitializedMigrationError].
+  ///
+  /// This is `false` when the migration was created with [Migration.deferred].
+  ///
+  /// Before calling [initialize] check [initialized],
+  /// so that you don't accidentally call it twice.
+  bool get initialized => _initialized;
 
   final FutureOr<({S up, S down})> Function(D db)? _renderer;
 
-  FutureOr<void> render(D db);
+  /// Initializes the migration by rendering the [up] and [down] migration
+  /// instructions.
+  ///
+  /// Throws [AlreadyInitializedMigrationError] if this migration was already initialized.
+  ///
+  /// To prevent this error, check [initialized] before calling this method.
+  @mustBeOverridden
+  @mustCallSuper
+  FutureOr<void> initialize(D db) {
+    if (_initialized) throw AlreadyInitializedMigrationError(this);
+    if (_renderer == null) {
+      throw StateError(
+          'Migration renderer is not set. Use Migration.deferred constructor to create a deferred migration.');
+    }
+  }
 
   /// The migration to apply to the database.
   ///
@@ -104,11 +172,11 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
   /// It should be able to be stored inside of the database.
   ///
   /// It's kept as a generic type since different databases might support storing different types of data.
-  S get up => _rendered ? _up : throw StateError('Migration not yet rendered');
+  S get up => _initialized ? _up : throw UninitializedMigrationError(this);
   late final S _up;
 
   /// The migration to undo the changes made by [up].
-  S get down => _rendered ? _down : throw StateError('Migration not yet rendered');
+  S get down => _initialized ? _down : throw UninitializedMigrationError(this);
   late final S _down;
 
   @override
@@ -164,7 +232,9 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
   }
 }
 
+/// {@macro dmwt.migration}
 class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
+  /// {@macro dmwt.migration.anon}
   SyncMigration({
     required super.definedAt,
     super.name,
@@ -175,15 +245,26 @@ class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
     required super.down,
   });
 
+  /// {@macro dmwt.migration.deferred}
+  SyncMigration.deferred({
+    required super.definedAt,
+    super.name,
+    super.description,
+    super.appliedAt,
+    super.alwaysApply,
+    required ({Serial up, Serial down}) Function(Db db) renderer,
+  }) : super.deferred(renderer: renderer);
+
   @override
-  SyncMigration<Db, Serial> copyWith(
-      {DateTime? definedAt,
-      String? name,
-      String? description,
-      DateTime? appliedAt,
-      bool? alwaysApply,
-      Serial? up,
-      Serial? down}) {
+  SyncMigration<Db, Serial> copyWith({
+    DateTime? definedAt,
+    String? name,
+    String? description,
+    DateTime? appliedAt,
+    bool? alwaysApply,
+    Serial? up,
+    Serial? down,
+  }) {
     return SyncMigration<Db, Serial>(
       definedAt: definedAt ?? this.definedAt,
       name: name ?? this.name,
@@ -196,19 +277,18 @@ class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
   }
 
   @override
-  void render(Db db) {
-    if (_renderer == null) return;
-    if (_rendered) {
-      throw StateError('Migration already rendered');
-    }
-    final result = _renderer(db) as ({Serial up, Serial down});
+  void initialize(Db db) {
+    super.initialize(db);
+    final result = _renderer!(db) as ({Serial up, Serial down});
     _up = result.up;
     _down = result.down;
-    _rendered = true;
+    _initialized = true;
   }
 }
 
+/// {@macro dmwt.migration}
 class AsyncMigration<Db, Serial> extends Migration<Db, Serial> {
+  /// {@macro dmwt.migration.anon}
   AsyncMigration({
     required super.definedAt,
     super.name,
@@ -219,28 +299,36 @@ class AsyncMigration<Db, Serial> extends Migration<Db, Serial> {
     required super.down,
   });
 
+  /// {@macro dmwt.migration.deferred}
+  AsyncMigration.deferred({
+    required super.definedAt,
+    super.name,
+    super.description,
+    super.appliedAt,
+    super.alwaysApply,
+    required super.renderer,
+  }) : super.deferred();
+
   @override
-  FutureOr<void> render(Db db) async {
-    if (_renderer == null) return Future.value();
-    if (_rendered) {
-      throw StateError('Migration already rendered');
-    }
-    final result = await _renderer(db);
+  FutureOr<void> initialize(Db db) async {
+    super.initialize(db);
+    final result = await _renderer!(db);
     _up = result.up;
     _down = result.down;
-    _rendered = true;
+    _initialized = true;
     return Future.value();
   }
 
   @override
-  AsyncMigration<Db, Serial> copyWith(
-      {DateTime? definedAt,
-      String? name,
-      String? description,
-      DateTime? appliedAt,
-      bool? alwaysApply,
-      Serial? up,
-      Serial? down}) {
+  AsyncMigration<Db, Serial> copyWith({
+    DateTime? definedAt,
+    String? name,
+    String? description,
+    DateTime? appliedAt,
+    bool? alwaysApply,
+    Serial? up,
+    Serial? down,
+  }) {
     return AsyncMigration<Db, Serial>(
       definedAt: definedAt ?? this.definedAt,
       name: name ?? this.name,

--- a/packages/generic/lib/src/migration.dart
+++ b/packages/generic/lib/src/migration.dart
@@ -31,7 +31,7 @@ class AlreadyInitializedMigrationError extends StateError {
 ///
 /// Migrations have to be serialized and deserialized preserving atleast [definedAt] and [down]
 /// to be able to make [SyncMigrator] work.
-/// 
+///
 /// [D] is the type of the database that the migration is applied to.
 /// [S] is the type of the migration instructions (for example, a SQL string).
 /// {@endtemplate}
@@ -162,10 +162,6 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
   @mustCallSuper
   FutureOr<void> buildInstructions(D db) {
     if (_hasInstructions) throw AlreadyInitializedMigrationError(this);
-    if (_instructionBuilder == null) {
-      throw StateError(
-          'Migration renderer is not set. Use Migration.deferred constructor to create a deferred migration.');
-    }
   }
 
   /// The migration to apply to the database.
@@ -268,6 +264,7 @@ class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
     Serial? up,
     Serial? down,
   }) {
+    if (!_hasInstructions) throw UninitializedMigrationError(this);
     return SyncMigration<Db, Serial>(
       definedAt: definedAt ?? this.definedAt,
       name: name ?? this.name,
@@ -332,6 +329,7 @@ class AsyncMigration<Db, Serial> extends Migration<Db, Serial> {
     Serial? up,
     Serial? down,
   }) {
+    if (!_hasInstructions) throw UninitializedMigrationError(this);
     return AsyncMigration<Db, Serial>(
       definedAt: definedAt ?? this.definedAt,
       name: name ?? this.name,

--- a/packages/generic/lib/src/migration.dart
+++ b/packages/generic/lib/src/migration.dart
@@ -79,9 +79,9 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
   /// manipulate the SQL string, than to copy paste the entire
   /// creation including all already made alterations again.
   ///
-  /// When using this constructor, you must call [build] before accessing [up] or [down].
+  /// When using this constructor, you must call [builder] before accessing [up] or [down].
   ///
-  /// When [build] is called, both [up] and [down] will be set.
+  /// When [builder] is called, both [up] and [down] will be set.
   /// This means effectively that a migration can be deferred
   /// in the app code, but when it is stored in the database,
   /// so that it can be rolled back, it will have been initialized.
@@ -92,7 +92,7 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
     this.description,
     this.appliedAt,
     this.alwaysApply = false,
-    required FutureOr<({S up, S down})> Function(D db) build,
+    required FutureOr<({S up, S down})> Function(D db) builder,
   })  : // Ensures that the DateTime is in UTC and also truncates the microseconds,
         // so that it's not a problem if microsecond precision is not supported by the database.
         definedAt = DateTime.fromMillisecondsSinceEpoch(
@@ -105,7 +105,7 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
               .millisecondsSinceEpoch,
           isUtc: true,
         ),
-        _instructionBuilder = build,
+        _instructionBuilder = builder,
         _hasInstructions = false;
 
   /// The identity of the migration.
@@ -255,8 +255,8 @@ class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
     super.description,
     super.appliedAt,
     super.alwaysApply,
-    required ({Serial up, Serial down}) Function(Db db) build,
-  }) : super.deferred(build: build);
+    required ({Serial up, Serial down}) Function(Db db) builder,
+  }) : super.deferred(builder: builder);
 
   @override
   SyncMigration<Db, Serial> copyWith({
@@ -309,7 +309,7 @@ class AsyncMigration<Db, Serial> extends Migration<Db, Serial> {
     super.description,
     super.appliedAt,
     super.alwaysApply,
-    required super.build,
+    required super.builder,
   }) : super.deferred();
 
   @override

--- a/packages/generic/lib/src/migration.dart
+++ b/packages/generic/lib/src/migration.dart
@@ -95,7 +95,7 @@ class Migration<T> implements Comparable<Migration<T>> {
 
   @override
   String toString() {
-    return 'Migration{definedAt: $definedAt, name: $name, decription: $description, alwaysApply: $alwaysApply, appliedAt: $appliedAt, up: $up, down: $down}';
+    return 'Migration{definedAt: $definedAt, name: $name, description: $description, alwaysApply: $alwaysApply, appliedAt: $appliedAt, up: $up, down: $down}';
   }
 
   /// A human-readable identifier for the migration. Used for debugging and logging.

--- a/packages/generic/lib/src/migration.dart
+++ b/packages/generic/lib/src/migration.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 //// {@template dmwmt.migration}
 /// A change to the database that can be applied and rolled back.
 ///
@@ -6,7 +8,7 @@
 /// Migrations have to be serialized and deserialized preserving atleast [definedAt] and [down]
 /// to be able to make [SyncMigrator] work.
 /// {endtemplate}
-class Migration<T> implements Comparable<Migration<T>> {
+sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
   /// Creates a new migration data class instance.
   ///
   /// Make sure that [definedAt] is unique for each migration and represents the time the code was edited.
@@ -18,9 +20,9 @@ class Migration<T> implements Comparable<Migration<T>> {
     this.description,
     this.appliedAt,
     this.alwaysApply = false,
-    required this.up,
-    required this.down,
-  }) : // Ensures that the DateTime is in UTC and also truncates the microseconds,
+    required S up,
+    required S down,
+  })  : // Ensures that the DateTime is in UTC and also truncates the microseconds,
         // so that it's not a problem if microsecond precision is not supported by the database.
         definedAt = DateTime.fromMillisecondsSinceEpoch(
           (() {
@@ -31,26 +33,33 @@ class Migration<T> implements Comparable<Migration<T>> {
           })()
               .millisecondsSinceEpoch,
           isUtc: true,
-        );
+        ),
+        _down = down,
+        _up = up,
+        _rendered = true,
+        _renderer = null;
 
-  /// Create a new [Migration] that undoes [migration]
-  /// by flipping its [up] and [down] fields.
-  Migration.undo({
+  Migration.deferred({
     required DateTime definedAt,
-    String? name,
-    String? description,
-    DateTime? appliedAt,
-    bool alwaysApply = false,
-    required Migration<T> migration,
-  }) : this(
-          definedAt: definedAt,
-          name: name ?? (migration.name != null ? "Undo ${migration.name}" : null),
-          description: description,
-          appliedAt: appliedAt,
-          alwaysApply: alwaysApply,
-          up: migration.down,
-          down: migration.up,
-        );
+    this.name,
+    this.description,
+    this.appliedAt,
+    this.alwaysApply = false,
+    required FutureOr<({S up, S down})> Function(D db) renderer,
+  })  : // Ensures that the DateTime is in UTC and also truncates the microseconds,
+        // so that it's not a problem if microsecond precision is not supported by the database.
+        definedAt = DateTime.fromMillisecondsSinceEpoch(
+          (() {
+            if (!definedAt.isUtc) {
+              throw ArgumentError.value(definedAt, 'definedAt', 'must be in UTC');
+            }
+            return definedAt;
+          })()
+              .millisecondsSinceEpoch,
+          isUtc: true,
+        ),
+        _renderer = renderer,
+        _rendered = false;
 
   /// The identity of the migration.
   ///
@@ -81,6 +90,13 @@ class Migration<T> implements Comparable<Migration<T>> {
   /// but also may be incompatible with some states of the database during the migration.
   final bool alwaysApply;
 
+  bool _rendered;
+  bool get rendered => _rendered;
+
+  final FutureOr<({S up, S down})> Function(D db)? _renderer;
+
+  FutureOr<void> render(D db);
+
   /// The migration to apply to the database.
   ///
   /// This could be a SQL string or a description of added and removed columns.
@@ -88,10 +104,12 @@ class Migration<T> implements Comparable<Migration<T>> {
   /// It should be able to be stored inside of the database.
   ///
   /// It's kept as a generic type since different databases might support storing different types of data.
-  final T up;
+  S get up => _rendered ? _up : throw StateError('Migration not yet rendered');
+  late final S _up;
 
   /// The migration to undo the changes made by [up].
-  final T down;
+  S get down => _rendered ? _down : throw StateError('Migration not yet rendered');
+  late final S _down;
 
   @override
   String toString() {
@@ -102,16 +120,79 @@ class Migration<T> implements Comparable<Migration<T>> {
   String get humanReadableId => name ?? definedAt.toString();
 
   /// Creates a copy of this migration with the given fields replaced with new values.
-  Migration<T> copyWith({
+  Migration<D, S> copyWith({
     DateTime? definedAt,
     String? name,
     String? description,
     DateTime? appliedAt,
     bool? alwaysApply,
-    T? up,
-    T? down,
-  }) {
-    return Migration<T>(
+    S? up,
+    S? down,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Migration && runtimeType == other.runtimeType && definedAt.isAtSameMomentAs(other.definedAt);
+
+  @override
+  int get hashCode => definedAt.hashCode;
+
+  @override
+  int compareTo(Migration<D, S> other) {
+    return definedAt.compareTo(other.definedAt);
+  }
+
+  /// Find out if this migration was defined before [other].
+  bool operator <(Migration<D, S> other) {
+    return definedAt.isBefore(other.definedAt);
+  }
+
+  /// Find out if this migration was defined after [other].
+  bool operator >(Migration<D, S> other) {
+    return definedAt.isAfter(other.definedAt);
+  }
+
+  /// Find out if this migration was defined before or at the same time as [other].
+  bool operator <=(Migration<D, S> other) {
+    return definedAt.isBefore(other.definedAt) || definedAt.isAtSameMomentAs(other.definedAt);
+  }
+
+  /// Find out if this migration was defined after or at the same time as [other].
+  bool operator >=(Migration<D, S> other) {
+    return definedAt.isAfter(other.definedAt) || definedAt.isAtSameMomentAs(other.definedAt);
+  }
+}
+
+class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
+  SyncMigration({
+    required DateTime definedAt,
+    String? name,
+    String? description,
+    DateTime? appliedAt,
+    bool alwaysApply = false,
+    required Serial up,
+    required Serial down,
+  }) : super(
+          definedAt: definedAt,
+          name: name,
+          description: description,
+          appliedAt: appliedAt,
+          alwaysApply: alwaysApply,
+          up: up,
+          down: down,
+        );
+
+  @override
+  SyncMigration<Db, Serial> copyWith(
+      {DateTime? definedAt,
+      String? name,
+      String? description,
+      DateTime? appliedAt,
+      bool? alwaysApply,
+      Serial? up,
+      Serial? down}) {
+    return SyncMigration<Db, Serial>(
       definedAt: definedAt ?? this.definedAt,
       name: name ?? this.name,
       description: description ?? this.description,
@@ -123,35 +204,67 @@ class Migration<T> implements Comparable<Migration<T>> {
   }
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is Migration && runtimeType == other.runtimeType && definedAt.isAtSameMomentAs(other.definedAt);
+  void render(Db db) {
+    if (_renderer == null) return;
+    if (_rendered) {
+      throw StateError('Migration already rendered');
+    }
+    final result = _renderer(db) as ({Serial up, Serial down});
+    _up = result.up;
+    _down = result.down;
+    _rendered = true;
+  }
+}
+
+class AsyncMigration<Db, Serial> extends Migration<Db, Serial> {
+  AsyncMigration({
+    required DateTime definedAt,
+    String? name,
+    String? description,
+    DateTime? appliedAt,
+    bool alwaysApply = false,
+    required Serial up,
+    required Serial down,
+  }) : super(
+          definedAt: definedAt,
+          name: name,
+          description: description,
+          appliedAt: appliedAt,
+          alwaysApply: alwaysApply,
+          up: up,
+          down: down,
+        );
 
   @override
-  int get hashCode => definedAt.hashCode;
+  FutureOr<void> render(Db db) async {
+    if (_renderer == null) return Future.value();
+    if (_rendered) {
+      throw StateError('Migration already rendered');
+    }
+    final result = await _renderer(db);
+    _up = result.up;
+    _down = result.down;
+    _rendered = true;
+    return Future.value();
+  }
 
   @override
-  int compareTo(Migration<T> other) {
-    return definedAt.compareTo(other.definedAt);
-  }
-
-  /// Find out if this migration was defined before [other].
-  bool operator <(Migration<T> other) {
-    return definedAt.isBefore(other.definedAt);
-  }
-
-  /// Find out if this migration was defined after [other].
-  bool operator >(Migration<T> other) {
-    return definedAt.isAfter(other.definedAt);
-  }
-
-  /// Find out if this migration was defined before or at the same time as [other].
-  bool operator <=(Migration<T> other) {
-    return definedAt.isBefore(other.definedAt) || definedAt.isAtSameMomentAs(other.definedAt);
-  }
-
-  /// Find out if this migration was defined after or at the same time as [other].
-  bool operator >=(Migration<T> other) {
-    return definedAt.isAfter(other.definedAt) || definedAt.isAtSameMomentAs(other.definedAt);
+  AsyncMigration<Db, Serial> copyWith(
+      {DateTime? definedAt,
+      String? name,
+      String? description,
+      DateTime? appliedAt,
+      bool? alwaysApply,
+      Serial? up,
+      Serial? down}) {
+    return AsyncMigration<Db, Serial>(
+      definedAt: definedAt ?? this.definedAt,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      appliedAt: appliedAt ?? this.appliedAt,
+      alwaysApply: alwaysApply ?? this.alwaysApply,
+      up: up ?? this.up,
+      down: down ?? this.down,
+    );
   }
 }

--- a/packages/generic/lib/src/migration.dart
+++ b/packages/generic/lib/src/migration.dart
@@ -79,9 +79,9 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
   /// manipulate the SQL string, than to copy paste the entire
   /// creation including all already made alterations again.
   ///
-  /// When using this constructor, you must call [buildInstructions] before accessing [up] or [down].
+  /// When using this constructor, you must call [build] before accessing [up] or [down].
   ///
-  /// When [buildInstructions] is called, both [up] and [down] will be set.
+  /// When [build] is called, both [up] and [down] will be set.
   /// This means effectively that a migration can be deferred
   /// in the app code, but when it is stored in the database,
   /// so that it can be rolled back, it will have been initialized.
@@ -92,7 +92,7 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
     this.description,
     this.appliedAt,
     this.alwaysApply = false,
-    required FutureOr<({S up, S down})> Function(D db) buildInstructions,
+    required FutureOr<({S up, S down})> Function(D db) build,
   })  : // Ensures that the DateTime is in UTC and also truncates the microseconds,
         // so that it's not a problem if microsecond precision is not supported by the database.
         definedAt = DateTime.fromMillisecondsSinceEpoch(
@@ -105,7 +105,7 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
               .millisecondsSinceEpoch,
           isUtc: true,
         ),
-        _instructionBuilder = buildInstructions,
+        _instructionBuilder = build,
         _hasInstructions = false;
 
   /// The identity of the migration.
@@ -255,8 +255,8 @@ class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
     super.description,
     super.appliedAt,
     super.alwaysApply,
-    required ({Serial up, Serial down}) Function(Db db) buildInstructions,
-  }) : super.deferred(buildInstructions: buildInstructions);
+    required ({Serial up, Serial down}) Function(Db db) build,
+  }) : super.deferred(build: build);
 
   @override
   SyncMigration<Db, Serial> copyWith({
@@ -309,7 +309,7 @@ class AsyncMigration<Db, Serial> extends Migration<Db, Serial> {
     super.description,
     super.appliedAt,
     super.alwaysApply,
-    required super.buildInstructions,
+    required super.build,
   }) : super.deferred();
 
   @override

--- a/packages/generic/lib/src/migration.dart
+++ b/packages/generic/lib/src/migration.dart
@@ -166,22 +166,14 @@ sealed class Migration<D, S> implements Comparable<Migration<D, S>> {
 
 class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
   SyncMigration({
-    required DateTime definedAt,
-    String? name,
-    String? description,
-    DateTime? appliedAt,
-    bool alwaysApply = false,
-    required Serial up,
-    required Serial down,
-  }) : super(
-          definedAt: definedAt,
-          name: name,
-          description: description,
-          appliedAt: appliedAt,
-          alwaysApply: alwaysApply,
-          up: up,
-          down: down,
-        );
+    required super.definedAt,
+    super.name,
+    super.description,
+    super.appliedAt,
+    super.alwaysApply,
+    required super.up,
+    required super.down,
+  });
 
   @override
   SyncMigration<Db, Serial> copyWith(
@@ -218,22 +210,14 @@ class SyncMigration<Db, Serial> extends Migration<Db, Serial> {
 
 class AsyncMigration<Db, Serial> extends Migration<Db, Serial> {
   AsyncMigration({
-    required DateTime definedAt,
-    String? name,
-    String? description,
-    DateTime? appliedAt,
-    bool alwaysApply = false,
-    required Serial up,
-    required Serial down,
-  }) : super(
-          definedAt: definedAt,
-          name: name,
-          description: description,
-          appliedAt: appliedAt,
-          alwaysApply: alwaysApply,
-          up: up,
-          down: down,
-        );
+    required super.definedAt,
+    super.name,
+    super.description,
+    super.appliedAt,
+    super.alwaysApply,
+    required super.up,
+    required super.down,
+  });
 
   @override
   FutureOr<void> render(Db db) async {

--- a/packages/generic/pubspec.yaml
+++ b/packages/generic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: db_migrations_with_multiverse_time_travel
 description: Runs database migrations for apps with local / embedded databases like SQLite. Check out different branches during development without having to reset the DB.
-version: 1.1.0
+version: 2.0.0
 repository: https://github.com/benthillerkus/db_migrations_with_multiverse_time_travel
 issue_tracker: https://github.com/benthillerkus/db_migrations_with_multiverse_time_travel/issues
 topics: ["database", "migration"]

--- a/packages/generic/test/advanced_scenarios_test.dart
+++ b/packages/generic/test/advanced_scenarios_test.dart
@@ -1,0 +1,266 @@
+// LLM generated code
+//
+// This is just intended to "harden" the test suite
+// and entrench current behavior.
+//
+// Since there is no intention behind these
+// they can just be removed and regenerated
+// if they conflict with future changes.
+
+import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
+import 'package:test/test.dart';
+
+import 'logging.dart';
+import 'mock_database.dart';
+
+void main() {
+  setUpAll(() {
+    setUpLogging();
+  });
+
+  group('Migration edge cases', () {
+    test('migration with null name and description', () {
+      final migration = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        up: #up,
+        down: #down,
+        name: null,
+        description: null,
+      );
+
+      expect(migration.name, isNull);
+      expect(migration.description, isNull);
+      expect(migration.humanReadableId, '2025-03-06 00:00:00.000Z');
+    });
+
+    test('migration with custom name has readable id', () {
+      final migration = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        up: #up,
+        down: #down,
+        name: 'Add Users Table',
+      );
+
+      expect(migration.humanReadableId, 'Add Users Table');
+    });
+
+    test('copyWith on uninitialized deferred migration throws', () {
+      final migration = SyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => (up: #up, down: #down),
+      );
+
+      expect(
+        () => migration.copyWith(name: 'New Name'),
+        throwsA(isA<UninitializedMigrationError>()),
+      );
+    });
+
+    test('copyWith on initialized deferred migration works', () {
+      final migration = SyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => (up: #up, down: #down),
+      );
+
+      migration.buildInstructions(null);
+
+      final copy = migration.copyWith(name: 'New Name');
+      expect(copy.name, 'New Name');
+      expect(copy.definedAt, migration.definedAt);
+      expect(copy.up, migration.up);
+      expect(copy.down, migration.down);
+    });
+
+    test('migration equality with different appliedAt times', () {
+      final migration1 = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        up: #up,
+        down: #down,
+        appliedAt: DateTime.utc(2025, 3, 6, 12, 0),
+      );
+
+      final migration2 = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        up: #up,
+        down: #down,
+        appliedAt: DateTime.utc(2025, 3, 6, 13, 0),
+      );
+
+      // Equality is based on definedAt, not appliedAt
+      expect(migration1, equals(migration2));
+      expect(migration1.hashCode, equals(migration2.hashCode));
+    });
+
+    test('migration toString includes all fields', () {
+      final migration = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        up: #up,
+        down: #down,
+        name: 'Test Migration',
+        description: 'A test migration',
+        appliedAt: DateTime.utc(2025, 3, 6, 12, 0),
+        alwaysApply: true,
+      );
+
+      final str = migration.toString();
+      expect(str, contains('Test Migration'));
+      expect(str, contains('A test migration'));
+      expect(str, contains('2025-03-06 00:00:00.000Z'));
+      expect(str, contains('2025-03-06 12:00:00.000Z'));
+      expect(str, contains('true'));
+    });
+
+    test('migration comparison operators', () {
+      final migration1 = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down);
+      final migration2 = Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down);
+      final migration3 = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down);
+
+      expect(migration1 < migration2, isTrue);
+      expect(migration1 > migration2, isFalse);
+      expect(migration1 <= migration2, isTrue);
+      expect(migration1 >= migration2, isFalse);
+      expect(migration1 <= migration3, isTrue);
+      expect(migration1 >= migration3, isTrue);
+    });
+  });
+
+  group('Always apply advanced scenarios', () {
+    test('multiple alwaysApply migrations in sequence', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #pragma1, down: #rollback1, alwaysApply: true),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #pragma2, down: #rollback2, alwaysApply: true),
+        Mig(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3, alwaysApply: false),
+        Mig(definedAt: DateTime.utc(2025, 3, 9), up: #pragma4, down: #rollback4, alwaysApply: true),
+      ];
+      final db = SyncMockDatabase(defined.take(3).toList()); // Only first 3 applied
+
+      migrator.call(db: db, defined: defined.iterator);
+
+      // Should apply all alwaysApply migrations and the new one
+      expect(db.performedMigrations, containsAllInOrder([#pragma1, #pragma2, #pragma4]));
+      expect(db.applied.length, 4);
+    });
+
+    test('alwaysApply deferred migration', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        SyncMigration<dynamic, Symbol>.deferred(
+          definedAt: DateTime.utc(2025, 3, 6),
+          builder: (_) => (up: #deferred_up, down: #deferred_down),
+          alwaysApply: true,
+        ),
+      ];
+      final db = SyncMockDatabase(defined);
+
+      migrator.call(db: db, defined: defined.iterator);
+
+      // Should build and apply the deferred migration
+      expect(db.performedMigrations, contains(#deferred_up));
+    });
+
+    test('alwaysApply migration that fails still rolls back', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #working, down: #rollback, alwaysApply: true),
+        SyncMigration<dynamic, Symbol>.deferred(
+          definedAt: DateTime.utc(2025, 3, 7),
+          builder: (_) => throw Exception('Build failed'),
+        ),
+      ];
+      final db = SyncMockDatabase(defined.take(1).toList());
+
+      expect(() => migrator.call(db: db, defined: defined.iterator), throwsException);
+      // Should have rolled back
+      expect(db.applied.length, 1); // Original state restored
+    });
+  });
+
+  group('Complex migration scenarios', () {
+    test('partial rollback then apply new migrations', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1),
+        Mig(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3), // Skip 7
+        Mig(definedAt: DateTime.utc(2025, 3, 10), up: #migration4, down: #rollback4),
+      ];
+
+      final applied = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #migration2, down: #rollback2),
+        Mig(definedAt: DateTime.utc(2025, 3, 9), up: #old_migration, down: #old_rollback),
+      ];
+
+      final db = SyncMockDatabase(applied);
+
+      migrator.call(db: db, defined: defined.iterator);
+
+      // Should rollback migrations 7 and 9, then apply 8 and 10
+      // Rollbacks are in reverse order: latest first
+      expect(db.performedMigrations, containsAllInOrder([#old_rollback, #rollback2, #migration3, #migration4]));
+      expect(db.applied.length, 3);
+      expect(db.applied.map((m) => m.definedAt), [
+        DateTime.utc(2025, 3, 6),
+        DateTime.utc(2025, 3, 8),
+        DateTime.utc(2025, 3, 10),
+      ]);
+    });
+
+    test('empty defined migrations with applied migrations rolls back everything', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final applied = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #migration2, down: #rollback2),
+        Mig(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3),
+      ];
+
+      final db = SyncMockDatabase(applied);
+
+      migrator.call(db: db, defined: <Mig>[].iterator);
+
+      // Should rollback everything in reverse order
+      expect(db.performedMigrations, [#rollback3, #rollback2, #rollback1]);
+      expect(db.applied, isEmpty);
+    });
+
+    test('migrations with same definedAt time comparison', () {
+      final time = DateTime.utc(2025, 3, 6);
+      final migration1 = Mig(definedAt: time, up: #migration1, down: #rollback1);
+      final migration2 = Mig(definedAt: time, up: #migration2, down: #rollback2);
+
+      expect(migration1.compareTo(migration2), 0);
+      expect(migration1 <= migration2, isTrue);
+      expect(migration1 >= migration2, isTrue);
+      expect(migration1 < migration2, isFalse);
+      expect(migration1 > migration2, isFalse);
+    });
+  });
+
+  group('AsyncMigrator working state', () {
+    test('working property is false initially', () {
+      final migrator = AsyncMigrator<dynamic, Symbol>();
+      expect(migrator.working, isFalse);
+    });
+
+    test('working property is true during migration', () async {
+      final migrator = AsyncMigrator<dynamic, Symbol>();
+      final defined = [
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = AsyncMockDatabase();
+
+      bool wasWorking = false;
+
+      final future = migrator.call(db: db, defined: defined.iterator).then((_) {
+        // After completion, should be false again
+        expect(migrator.working, isFalse);
+      });
+
+      // During migration, should be true
+      wasWorking = migrator.working;
+
+      await future;
+      expect(wasWorking, isTrue);
+    });
+  });
+}

--- a/packages/generic/test/algorithm_test.dart
+++ b/packages/generic/test/algorithm_test.dart
@@ -157,4 +157,48 @@ void main() {
       expect(eq.equals(db.applied, defined), isTrue);
     });
   });
+
+  group('SyncMigrateExt', () {
+    test('migrate applies migrations in order', () {
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+      ];
+      final db = SyncMockDatabase();
+
+      db.migrate(defined);
+
+      expect(db.applied, defined);
+    });
+
+    test('migrate with empty list does nothing', () {
+      final db = SyncMockDatabase();
+
+      db.migrate([]);
+
+      expect(db.applied, isEmpty);
+    });
+  });
+
+  group('AsyncMigrateExt', () {
+    test('migrate applies migrations in order', () async {
+      final defined = [
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+      ];
+      final db = AsyncMockDatabase();
+
+      await db.migrate(defined);
+
+      expect(db.applied, defined);
+    });
+
+    test('migrate with empty list does nothing', () async {
+      final db = AsyncMockDatabase();
+
+      await db.migrate([]);
+
+      expect(db.applied, isEmpty);
+    });
+  });
 }

--- a/packages/generic/test/algorithm_test.dart
+++ b/packages/generic/test/algorithm_test.dart
@@ -88,7 +88,6 @@ void main() {
     final migrator = AsyncMigrator<Null, Symbol>();
     final eq = IterableEquality<AMig>();
 
-
     test("Empty", () async {
       await migrator.call(db: AsyncMockDatabase(), defined: <AMig>[].iterator);
     });

--- a/packages/generic/test/algorithm_test.dart
+++ b/packages/generic/test/algorithm_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   group("Sync", () {
-    final migrator = SyncMigrator<Null, Symbol>();
+    final migrator = SyncMigrator<dynamic, Symbol>();
     final eq = IterableEquality<Mig>();
 
     test("Empty", () {
@@ -61,7 +61,7 @@ void main() {
         Mig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ]);
 
-      SyncMigrator<Null, Symbol>().call(db: db, defined: <Mig>[].iterator);
+      SyncMigrator<dynamic, Symbol>().call(db: db, defined: <Mig>[].iterator);
 
       expect(db.applied, isEmpty);
     });
@@ -78,14 +78,14 @@ void main() {
         Mig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ]);
 
-      SyncMigrator<Null, Symbol>().call(db: db, defined: defined.iterator);
+      SyncMigrator<dynamic, Symbol>().call(db: db, defined: defined.iterator);
 
       expect(eq.equals(db.applied, defined), isTrue);
     });
   });
 
   group("Async", () {
-    final migrator = AsyncMigrator<Null, Symbol>();
+    final migrator = AsyncMigrator<dynamic, Symbol>();
     final eq = IterableEquality<AMig>();
 
     test("Empty", () async {
@@ -135,7 +135,7 @@ void main() {
         AMig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ]);
 
-      await AsyncMigrator<Null, Symbol>().call(db: db, defined: <AMig>[].iterator);
+      await AsyncMigrator<dynamic, Symbol>().call(db: db, defined: <AMig>[].iterator);
 
       expect(db.applied, isEmpty);
     });
@@ -152,7 +152,7 @@ void main() {
         AMig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ]);
 
-      await AsyncMigrator<Null, Symbol>().call(db: db, defined: defined.iterator);
+      await AsyncMigrator<dynamic, Symbol>().call(db: db, defined: defined.iterator);
 
       expect(eq.equals(db.applied, defined), isTrue);
     });

--- a/packages/generic/test/algorithm_test.dart
+++ b/packages/generic/test/algorithm_test.dart
@@ -10,18 +10,17 @@ void main() {
     setUpLogging();
   });
 
-  final eq = IterableEquality<Migration<void>>();
-
   group("Sync", () {
-    final migrator = SyncMigrator<void>();
+    final migrator = SyncMigrator<Null, Symbol>();
+    final eq = IterableEquality<Mig>();
 
     test("Empty", () {
-      migrator.call(db: SyncMockDatabase(), defined: <Migration<void>>[].iterator);
+      migrator.call(db: SyncMockDatabase(), defined: <Mig>[].iterator);
     });
 
     test("Single migration", () {
-      final defined = [Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null)];
-      final db = SyncMockDatabase<void>();
+      final defined = [Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down)];
+      final db = SyncMockDatabase();
 
       migrator.call(db: db, defined: defined.iterator);
 
@@ -30,11 +29,11 @@ void main() {
 
     test("Multiple migrations", () {
       final defined = [
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 8), up: null, down: null),
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ];
-      final db = SyncMockDatabase<void>();
+      final db = SyncMockDatabase();
 
       migrator.call(db: db, defined: defined.iterator);
 
@@ -43,11 +42,11 @@ void main() {
 
     test("Wrong order throws", () {
       final defined = [
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 5), up: null, down: null),
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 5), up: #up, down: #down),
       ];
-      final db = SyncMockDatabase<void>();
+      final db = SyncMockDatabase();
 
       expect(() => migrator.call(db: db, defined: defined.iterator), throwsA(isA<StateError>()));
 
@@ -57,44 +56,46 @@ void main() {
 
     test('Rollback no common', () {
       final db = SyncMockDatabase([
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 8), up: null, down: null),
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ]);
 
-      SyncMigrator<Null>().call(db: db, defined: <Migration<Null>>[].iterator);
+      SyncMigrator<Null, Symbol>().call(db: db, defined: <Mig>[].iterator);
 
       expect(db.applied, isEmpty);
     });
 
     test('Rollback some common', () {
       final defined = [
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 9), up: null, down: null),
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 9), up: #up, down: #down),
       ];
 
       final db = SyncMockDatabase([
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 8), up: null, down: null),
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ]);
 
-      SyncMigrator<Null>().call(db: db, defined: defined.iterator);
+      SyncMigrator<Null, Symbol>().call(db: db, defined: defined.iterator);
 
       expect(eq.equals(db.applied, defined), isTrue);
     });
   });
 
   group("Async", () {
-    final migrator = AsyncMigrator<void>();
+    final migrator = AsyncMigrator<Null, Symbol>();
+    final eq = IterableEquality<AMig>();
+
 
     test("Empty", () async {
-      await migrator.call(db: AsyncMockDatabase(), defined: <Migration<void>>[].iterator);
+      await migrator.call(db: AsyncMockDatabase(), defined: <AMig>[].iterator);
     });
 
     test("Single migration", () async {
-      final defined = [Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null)];
-      final db = AsyncMockDatabase<void>();
+      final defined = [AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down)];
+      final db = AsyncMockDatabase();
 
       await migrator.call(db: db, defined: defined.iterator);
 
@@ -103,11 +104,11 @@ void main() {
 
     test("Multiple migrations", () async {
       final defined = [
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 8), up: null, down: null),
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ];
-      final db = AsyncMockDatabase<void>();
+      final db = AsyncMockDatabase();
 
       await migrator.call(db: db, defined: defined.iterator);
 
@@ -116,11 +117,11 @@ void main() {
 
     test("Wrong order throws", () async {
       final defined = [
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 5), up: null, down: null),
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 5), up: #up, down: #down),
       ];
-      final db = AsyncMockDatabase<void>();
+      final db = AsyncMockDatabase();
 
       await expectLater(() => migrator.call(db: db, defined: defined.iterator), throwsA(isA<StateError>()));
 
@@ -130,29 +131,29 @@ void main() {
 
     test('Rollback no common', () async {
       final db = AsyncMockDatabase([
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 8), up: null, down: null),
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ]);
 
-      await AsyncMigrator<Null>().call(db: db, defined: <Migration<Null>>[].iterator);
+      await AsyncMigrator<Null, Symbol>().call(db: db, defined: <AMig>[].iterator);
 
       expect(db.applied, isEmpty);
     });
 
     test('Rollback some common', () async {
       final defined = [
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 9), up: null, down: null),
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 9), up: #up, down: #down),
       ];
 
       final db = AsyncMockDatabase([
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null),
-        Migration(definedAt: DateTime.utc(2025, 3, 8), up: null, down: null),
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down),
       ]);
 
-      await AsyncMigrator<Null>().call(db: db, defined: defined.iterator);
+      await AsyncMigrator<Null, Symbol>().call(db: db, defined: defined.iterator);
 
       expect(eq.equals(db.applied, defined), isTrue);
     });

--- a/packages/generic/test/always_apply_test.dart
+++ b/packages/generic/test/always_apply_test.dart
@@ -1,0 +1,45 @@
+import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
+import 'package:test/test.dart';
+
+import 'logging.dart';
+import 'mock_database.dart';
+
+void main() {
+  setUpAll(() {
+    setUpLogging();
+  });
+
+  group("Sync", () {
+    final migrator = SyncMigrator<Symbol>();
+
+    test("Some always apply", () {
+      final defined = [
+        Migration(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1, alwaysApply: true),
+        Migration(definedAt: DateTime.utc(2025, 3, 7), up: #migration2, down: #rollback2, alwaysApply: false),
+        Migration(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3, alwaysApply: true),
+      ];
+      final db = SyncMockDatabase<Symbol>(defined);
+
+      migrator.call(db: db, defined: defined.iterator);
+      expect(
+          db.performedMigrations, allOf(containsAllInOrder([#migration1, #migration3]), isNot(contains(#migration2))));
+    });
+  });
+
+  group("Async", () {
+    final migrator = AsyncMigrator<Symbol>();
+
+    test("Some always apply", () async {
+      final defined = [
+        Migration(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1, alwaysApply: true),
+        Migration(definedAt: DateTime.utc(2025, 3, 7), up: #migration2, down: #rollback2, alwaysApply: false),
+        Migration(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3, alwaysApply: true),
+      ];
+      final db = AsyncMockDatabase<Symbol>(defined);
+
+      await migrator.call(db: db, defined: defined.iterator);
+      expect(
+          db.performedMigrations, allOf(containsAllInOrder([#migration1, #migration3]), isNot(contains(#migration2))));
+    });
+  });
+}

--- a/packages/generic/test/always_apply_test.dart
+++ b/packages/generic/test/always_apply_test.dart
@@ -10,7 +10,7 @@ void main() {
   });
 
   group("Sync", () {
-    final migrator = SyncMigrator<void, Symbol>();
+    final migrator = SyncMigrator<dynamic, Symbol>();
 
     test("Some always apply", () {
       final defined = [
@@ -27,7 +27,7 @@ void main() {
   });
 
   group("Async", () {
-    final migrator = AsyncMigrator<Null, Symbol>();
+    final migrator = AsyncMigrator<dynamic, Symbol>();
 
     test("Some always apply", () async {
       final defined = [

--- a/packages/generic/test/always_apply_test.dart
+++ b/packages/generic/test/always_apply_test.dart
@@ -10,15 +10,15 @@ void main() {
   });
 
   group("Sync", () {
-    final migrator = SyncMigrator<Symbol>();
+    final migrator = SyncMigrator<void, Symbol>();
 
     test("Some always apply", () {
       final defined = [
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1, alwaysApply: true),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: #migration2, down: #rollback2, alwaysApply: false),
-        Migration(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3, alwaysApply: true),
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1, alwaysApply: true),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #migration2, down: #rollback2, alwaysApply: false),
+        Mig(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3, alwaysApply: true),
       ];
-      final db = SyncMockDatabase<Symbol>(defined);
+      final db = SyncMockDatabase(defined);
 
       migrator.call(db: db, defined: defined.iterator);
       expect(
@@ -27,15 +27,15 @@ void main() {
   });
 
   group("Async", () {
-    final migrator = AsyncMigrator<Symbol>();
+    final migrator = AsyncMigrator<Null, Symbol>();
 
     test("Some always apply", () async {
       final defined = [
-        Migration(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1, alwaysApply: true),
-        Migration(definedAt: DateTime.utc(2025, 3, 7), up: #migration2, down: #rollback2, alwaysApply: false),
-        Migration(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3, alwaysApply: true),
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #migration1, down: #rollback1, alwaysApply: true),
+        AMig(definedAt: DateTime.utc(2025, 3, 7), up: #migration2, down: #rollback2, alwaysApply: false),
+        AMig(definedAt: DateTime.utc(2025, 3, 8), up: #migration3, down: #rollback3, alwaysApply: true),
       ];
-      final db = AsyncMockDatabase<Symbol>(defined);
+      final db = AsyncMockDatabase(defined);
 
       await migrator.call(db: db, defined: defined.iterator);
       expect(

--- a/packages/generic/test/deferred_test.dart
+++ b/packages/generic/test/deferred_test.dart
@@ -1,7 +1,4 @@
-import 'dart:math';
-
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
-import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import 'logging.dart';

--- a/packages/generic/test/deferred_test.dart
+++ b/packages/generic/test/deferred_test.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
 import 'package:test/test.dart';

--- a/packages/generic/test/deferred_test.dart
+++ b/packages/generic/test/deferred_test.dart
@@ -1,0 +1,43 @@
+import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
+import 'package:test/test.dart';
+
+import 'logging.dart';
+
+void main() {
+  setUpAll(() {
+    setUpLogging();
+  });
+
+  test("Can directly access up on regular migration", () {
+    final mig = SyncMigration<void, String>(
+      definedAt: DateTime.utc(2025, 3, 6),
+      up: 'up',
+      down: 'down',
+    );
+
+    expect(mig.up, 'up');
+    expect(mig.down, 'down');
+  });
+
+  test("Accessing up on uninitialized deferred migration throws", () {
+    final mig = SyncMigration<void, String>.deferred(
+      definedAt: DateTime.utc(2025, 3, 6),
+      builder: (_) => (up: 'up', down: 'down'),
+    );
+
+    expect(() => mig.up, throwsA(isA<UninitializedMigrationError>()));
+    expect(() => mig.down, throwsA(isA<UninitializedMigrationError>()));
+  });
+
+  test("Accessing up on initialized deferred migration works", () {
+    final mig = SyncMigration<void, String>.deferred(
+      definedAt: DateTime.utc(2025, 3, 6),
+      builder: (_) => (up: 'up', down: 'down'),
+    );
+
+    mig.buildInstructions(null);
+
+    expect(mig.up, 'up');
+    expect(mig.down, 'down');
+  });
+}

--- a/packages/generic/test/deferred_test.dart
+++ b/packages/generic/test/deferred_test.dart
@@ -40,4 +40,24 @@ void main() {
     expect(mig.up, 'up');
     expect(mig.down, 'down');
   });
+
+  test("Initializing twice is forbidden", () {
+    final mig = SyncMigration<void, String>.deferred(
+      definedAt: DateTime.utc(2025, 3, 6),
+      builder: (_) => (up: 'up', down: 'down'),
+    );
+
+    mig.buildInstructions(null);
+
+    expect(() => mig.buildInstructions(null), throwsA(isA<AlreadyInitializedMigrationError>()));
+  });
+
+  test("Cannot call copyWith on uninitialized deferred migration", () {
+    final mig = SyncMigration<void, String>.deferred(
+      definedAt: DateTime.utc(2025, 3, 6),
+      builder: (_) => (up: 'up', down: 'down'),
+    );
+
+    expect(() => mig.copyWith(appliedAt: DateTime.utc(2070)), throwsA(isA<UninitializedMigrationError>()));
+  });
 }

--- a/packages/generic/test/deferred_test.dart
+++ b/packages/generic/test/deferred_test.dart
@@ -1,4 +1,7 @@
+import 'dart:math';
+
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import 'logging.dart';
@@ -64,6 +67,24 @@ void main() {
 
   group("Sync", () {
     test("Deferred migrations are being initialized during migration", () {
+      log.info("Setting up stuff");
+      makeSecondMigration() => SyncMigration<Map<Symbol, dynamic>, Symbol>.deferred(
+            definedAt: DateTime.utc(2025, 4),
+            alwaysApply: true,
+            builder: (db) {
+              expect(db, contains(#first));
+              if (db.containsKey(#second)) {
+                db[#second] += 1;
+              } else {
+                db[#second] = 1;
+              }
+              return (up: #fourUp, down: #fourDown);
+            },
+          );
+
+      expect(makeSecondMigration(), makeSecondMigration());
+      expect(makeSecondMigration().hasInstructions, isFalse);
+
       final migrations = <SyncMigration<Map<Symbol, dynamic>, Symbol>>[
         SyncMigration.deferred(
           definedAt: DateTime.utc(2025, 3, 6),
@@ -73,35 +94,45 @@ void main() {
             return (up: #oneUp, down: #oneDown);
           },
         ),
-        SyncMigration.deferred(
-          definedAt: DateTime.utc(2025, 4),
-          alwaysApply: true,
-          builder: (db) {
-            expect(db, contains(#first));
-            if (db.containsKey(#second)) {
-              db[#second] += 1;
-            } else {
-              db[#second] = 1;
-            }
-            return (up: #fourUp, down: #fourDown);
-          },
-        ),
+        makeSecondMigration(),
         SyncMigration(definedAt: DateTime.utc(2026), alwaysApply: true, up: #twoUp, down: #twoDown),
         SyncMigration(definedAt: DateTime.utc(2036), up: #threeUp, down: #threeDown),
       ];
 
+      log.info("Starting first migration");
       final migrator = SyncMigrator<dynamic, Symbol>();
       final db = SyncMockDatabase([], <Symbol, dynamic>{});
-
       migrator.call(db: db, defined: migrations.iterator);
 
       expect(db.db, allOf(containsPair(#first, true), containsPair(#second, 1)));
 
+      log.info("Starting second migration");
       final db2 = SyncMockDatabase([], db.db);
       migrator.call(db: db2, defined: migrations.iterator);
 
-      expect(db2.db, allOf(containsPair(#first, true), containsPair(#second, 1)),
-          reason: "Deferred migrations should not be re-initialized if they have already been run.");
+      expect(
+        db2.db,
+        allOf(containsPair(#first, true), containsPair(#second, 1)),
+        reason: "Deferred migrations should not be re-initialized if they have already been run.",
+      );
+
+      expect(
+        migrations,
+        everyElement(
+          isA<SyncMigration<Map<Symbol, dynamic>, Symbol>>()
+              .having((m) => m.hasInstructions, "has instructions", isTrue),
+        ),
+      );
+
+      log.info("Starting third migration");
+      // "Reset" the second migration so that it's uninitialized again.
+      migrations.replaceRange(1, 2, [makeSecondMigration()]);
+      expect(migrations[1].hasInstructions, isFalse);
+      expect(migrations, hasLength(4));
+
+      db.migrate(migrations);
+
+      expect(db.db, allOf(containsPair(#first, true), containsPair(#second, 2)));
     });
   });
 }

--- a/packages/generic/test/deferred_test.dart
+++ b/packages/generic/test/deferred_test.dart
@@ -1,4 +1,3 @@
-
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
 import 'package:test/test.dart';
 

--- a/packages/generic/test/error_handling_test.dart
+++ b/packages/generic/test/error_handling_test.dart
@@ -1,0 +1,332 @@
+// LLM generated code
+//
+// This is just intended to "harden" the test suite
+// and entrench current behavior.
+//
+// Since there is no intention behind these
+// they can just be removed and regenerated
+// if they conflict with future changes.
+
+import 'dart:async';
+
+import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
+import 'package:test/test.dart';
+
+import 'logging.dart';
+import 'mock_database.dart';
+
+class FailingMockDatabase extends SyncMockDatabase {
+  FailingMockDatabase({
+    this.shouldFailOnTransaction = false,
+    this.shouldFailOnCommit = false,
+    this.shouldFailOnRollback = false,
+    this.shouldFailOnExecute = false,
+    this.shouldFailOnTableInit = false,
+  });
+
+  final bool shouldFailOnTransaction;
+  final bool shouldFailOnCommit;
+  final bool shouldFailOnRollback;
+  final bool shouldFailOnExecute;
+  final bool shouldFailOnTableInit;
+
+  @override
+  void beginTransaction() {
+    if (shouldFailOnTransaction) {
+      throw Exception('Transaction failed');
+    }
+    super.beginTransaction();
+  }
+
+  @override
+  void commitTransaction() {
+    if (shouldFailOnCommit) {
+      throw Exception('Commit failed');
+    }
+    super.commitTransaction();
+  }
+
+  @override
+  void rollbackTransaction() {
+    if (shouldFailOnRollback) {
+      throw Exception('Rollback failed');
+    }
+    super.rollbackTransaction();
+  }
+
+  @override
+  void executeInstructions(Symbol migration) {
+    if (shouldFailOnExecute) {
+      throw Exception('Execute instructions failed');
+    }
+    super.executeInstructions(migration);
+  }
+
+  @override
+  void initializeMigrationsTable() {
+    if (shouldFailOnTableInit) {
+      throw Exception('Table initialization failed');
+    }
+    super.initializeMigrationsTable();
+  }
+}
+
+class FailingAsyncMockDatabase extends AsyncMockDatabase {
+  FailingAsyncMockDatabase({
+    this.shouldFailOnTransaction = false,
+    this.shouldFailOnCommit = false,
+    this.shouldFailOnRollback = false,
+    this.shouldFailOnExecute = false,
+    this.shouldFailOnTableInit = false,
+  });
+
+  final bool shouldFailOnTransaction;
+  final bool shouldFailOnCommit;
+  final bool shouldFailOnRollback;
+  final bool shouldFailOnExecute;
+  final bool shouldFailOnTableInit;
+
+  @override
+  Future<void> beginTransaction() async {
+    if (shouldFailOnTransaction) {
+      throw Exception('Transaction failed');
+    }
+    await super.beginTransaction();
+  }
+
+  @override
+  Future<void> commitTransaction() async {
+    if (shouldFailOnCommit) {
+      throw Exception('Commit failed');
+    }
+    await super.commitTransaction();
+  }
+
+  @override
+  Future<void> rollbackTransaction() async {
+    if (shouldFailOnRollback) {
+      throw Exception('Rollback failed');
+    }
+    await super.rollbackTransaction();
+  }
+
+  @override
+  Future<void> executeInstructions(Symbol migration) async {
+    if (shouldFailOnExecute) {
+      throw Exception('Execute instructions failed');
+    }
+    await super.executeInstructions(migration);
+  }
+
+  @override
+  Future<void> initializeMigrationsTable() async {
+    if (shouldFailOnTableInit) {
+      throw Exception('Table initialization failed');
+    }
+    await super.initializeMigrationsTable();
+  }
+}
+
+void main() {
+  setUpAll(() {
+    setUpLogging();
+  });
+
+  group('Sync Error Handling', () {
+    test('handles transaction failure gracefully', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = FailingMockDatabase(shouldFailOnTransaction: true);
+
+      expect(() => migrator.call(db: db, defined: defined.iterator), throwsException);
+      expect(db.applied, isEmpty);
+    });
+
+    test('handles commit failure with rollback', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = FailingMockDatabase(shouldFailOnCommit: true);
+
+      expect(() => migrator.call(db: db, defined: defined.iterator), throwsException);
+      // Should have attempted rollback
+      expect(db.applied, isEmpty);
+    });
+
+    test('handles execute instructions failure with rollback', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = FailingMockDatabase(shouldFailOnExecute: true);
+
+      expect(() => migrator.call(db: db, defined: defined.iterator), throwsException);
+      expect(db.applied, isEmpty);
+    });
+
+    test('handles table initialization failure', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = FailingMockDatabase(shouldFailOnTableInit: true);
+      db.migrationsTableInitialized = false;
+
+      expect(() => migrator.call(db: db, defined: defined.iterator), throwsException);
+    });
+
+    test('handles deferred migration build failure', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        SyncMigration<dynamic, Symbol>.deferred(
+          definedAt: DateTime.utc(2025, 3, 6),
+          builder: (_) => throw Exception('Build failed'),
+        ),
+      ];
+      final db = SyncMockDatabase();
+
+      expect(() => migrator.call(db: db, defined: defined.iterator), throwsException);
+      expect(db.applied, isEmpty);
+    });
+  });
+
+  group('Async Error Handling', () {
+    test('handles concurrent modification error', () async {
+      final migrator = AsyncMigrator<dynamic, Symbol>();
+      final defined = [
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = AsyncMockDatabase();
+
+      // Start first migration
+      final future1 = migrator.call(db: db, defined: defined.iterator);
+
+      // Try to start second migration while first is running
+      expect(
+        () => migrator.call(db: db, defined: defined.iterator),
+        throwsA(isA<ConcurrentModificationError>()),
+      );
+
+      await future1; // Complete first migration
+    });
+
+    test('handles transaction failure gracefully', () async {
+      final migrator = AsyncMigrator<dynamic, Symbol>();
+      final defined = [
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = FailingAsyncMockDatabase(shouldFailOnTransaction: true);
+
+      await expectLater(
+        () => migrator.call(db: db, defined: defined.iterator),
+        throwsException,
+      );
+      expect(db.applied, isEmpty);
+    });
+
+    test('handles commit failure with rollback', () async {
+      final migrator = AsyncMigrator<dynamic, Symbol>();
+      final defined = [
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = FailingAsyncMockDatabase(shouldFailOnCommit: true);
+
+      await expectLater(
+        () => migrator.call(db: db, defined: defined.iterator),
+        throwsException,
+      );
+      expect(db.applied, isEmpty);
+    });
+
+    test('handles execute instructions failure with rollback', () async {
+      final migrator = AsyncMigrator<dynamic, Symbol>();
+      final defined = [
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+      final db = FailingAsyncMockDatabase(shouldFailOnExecute: true);
+
+      await expectLater(
+        () => migrator.call(db: db, defined: defined.iterator),
+        throwsException,
+      );
+      expect(db.applied, isEmpty);
+    });
+
+    test('handles deferred migration build failure', () async {
+      final migrator = AsyncMigrator<dynamic, Symbol>();
+      final defined = [
+        AsyncMigration<dynamic, Symbol>.deferred(
+          definedAt: DateTime.utc(2025, 3, 6),
+          builder: (_) => throw Exception('Build failed'),
+        ),
+      ];
+      final db = AsyncMockDatabase();
+
+      await expectLater(
+        () => migrator.call(db: db, defined: defined.iterator),
+        throwsException,
+      );
+      expect(db.applied, isEmpty);
+    });
+
+    test('can work again after error', () async {
+      final defined = [
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ];
+
+      // First call fails
+      final migrator1 = AsyncMigrator<dynamic, Symbol>();
+      final failingDb = FailingAsyncMockDatabase(shouldFailOnExecute: true);
+      await expectLater(
+        () => migrator1.call(db: failingDb, defined: defined.iterator),
+        throwsException,
+      );
+
+      // Second call with new migrator should work
+      final migrator2 = AsyncMigrator<dynamic, Symbol>();
+      final workingDb = AsyncMockDatabase();
+      await migrator2.call(db: workingDb, defined: defined.iterator);
+      expect(workingDb.applied, isNotEmpty);
+    });
+  });
+
+  group('Applied migrations order validation', () {
+    test('sync - throws when applied migrations are out of order', () {
+      final migrator = SyncMigrator<dynamic, Symbol>();
+      final defined = [
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+      ];
+
+      // Create database with migrations in wrong order
+      final db = SyncMockDatabase([
+        Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ]);
+
+      expect(() => migrator.call(db: db, defined: defined.iterator), throwsA(isA<StateError>()));
+    });
+
+    test('async - throws when applied migrations are out of order', () async {
+      final migrator = AsyncMigrator<dynamic, Symbol>();
+      final defined = [
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+      ];
+
+      // Create database with migrations in wrong order
+      final db = AsyncMockDatabase([
+        AMig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down),
+        AMig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down),
+      ]);
+
+      await expectLater(
+        () => migrator.call(db: db, defined: defined.iterator),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}

--- a/packages/generic/test/logging.dart
+++ b/packages/generic/test/logging.dart
@@ -3,8 +3,11 @@ import 'dart:developer' as developer;
 import 'package:ansicolor/ansicolor.dart';
 import 'package:logging/logging.dart';
 
+late Logger log;
+
 void setUpLogging() {
   Logger.root.level = Level.ALL;
+  log = Logger('test');
   final pen = AnsiPen();
   Logger.root.onRecord.listen((record) {
     switch (record.level) {

--- a/packages/generic/test/migration_edge_cases_test.dart
+++ b/packages/generic/test/migration_edge_cases_test.dart
@@ -1,0 +1,349 @@
+// LLM generated code
+//
+// This is just intended to "harden" the test suite
+// and entrench current behavior.
+//
+// Since there is no intention behind these
+// they can just be removed and regenerated
+// if they conflict with future changes.
+
+import 'dart:async';
+
+import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
+import 'package:test/test.dart';
+
+import 'logging.dart';
+import 'mock_database.dart';
+
+void main() {
+  setUpAll(() {
+    setUpLogging();
+  });
+
+  group('Deferred Migration Edge Cases', () {
+    test('sync deferred migration builder cannot be async', () {
+      // This test demonstrates that the sync migration builder must return sync results
+      final migration = SyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => (up: #up, down: #down), // sync builder for sync migration
+      );
+
+      migration.buildInstructions(null);
+      expect(migration.hasInstructions, isTrue);
+    });
+
+    test('async deferred migration with sync builder works', () async {
+      final migration = AsyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => (up: #up, down: #down), // sync builder for async migration
+      );
+
+      await migration.buildInstructions(null);
+      expect(migration.hasInstructions, isTrue);
+      expect(migration.up, #up);
+      expect(migration.down, #down);
+    });
+
+    test('async deferred migration with async builder works', () async {
+      final migration = AsyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => (up: #up, down: #down),
+      );
+
+      await migration.buildInstructions(null);
+      expect(migration.hasInstructions, isTrue);
+      expect(migration.up, #up);
+      expect(migration.down, #down);
+    });
+
+    test('deferred migration builder receives database instance', () {
+      dynamic receivedDb;
+      final migration = SyncMigration<String, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (db) {
+          receivedDb = db;
+          return (up: #up, down: #down);
+        },
+      );
+
+      const dbInstance = 'test-database';
+      migration.buildInstructions(dbInstance);
+
+      expect(receivedDb, equals(dbInstance));
+    });
+
+    test('async deferred migration builder receives database instance', () async {
+      dynamic receivedDb;
+      final migration = AsyncMigration<String, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (db) {
+          receivedDb = db;
+          return (up: #up, down: #down);
+        },
+      );
+
+      const dbInstance = 'test-database';
+      await migration.buildInstructions(dbInstance);
+
+      expect(receivedDb, equals(dbInstance));
+    });
+
+    test('deferred migration can use database to build instructions', () {
+      final migration = SyncMigration<Map<String, dynamic>, String>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (db) {
+          final tableName = db['tableName'] as String;
+          return (
+            up: 'CREATE TABLE $tableName (id INTEGER)',
+            down: 'DROP TABLE $tableName',
+          );
+        },
+      );
+
+      migration.buildInstructions({'tableName': 'users'});
+
+      expect(migration.up, 'CREATE TABLE users (id INTEGER)');
+      expect(migration.down, 'DROP TABLE users');
+    });
+
+    test('async deferred migration handles async database operations', () async {
+      final migration = AsyncMigration<Future<String>, String>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (dbFuture) async {
+          final tableName = await dbFuture;
+          return (
+            up: 'CREATE TABLE $tableName (id INTEGER)',
+            down: 'DROP TABLE $tableName',
+          );
+        },
+      );
+
+      await migration.buildInstructions(Future.value('async_users'));
+
+      expect(migration.up, 'CREATE TABLE async_users (id INTEGER)');
+      expect(migration.down, 'DROP TABLE async_users');
+    });
+
+    test('double initialization of deferred migration throws', () {
+      final migration = SyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => (up: #up, down: #down),
+      );
+
+      migration.buildInstructions(null);
+
+      expect(
+        () => migration.buildInstructions(null),
+        throwsA(isA<AlreadyInitializedMigrationError>()),
+      );
+    });
+
+    test('async double initialization of deferred migration throws', () async {
+      final migration = AsyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => (up: #up, down: #down),
+      );
+
+      await migration.buildInstructions(null);
+
+      await expectLater(
+        () => migration.buildInstructions(null),
+        throwsA(isA<AlreadyInitializedMigrationError>()),
+      );
+    });
+
+    test('deferred migration builder exception is propagated', () {
+      final migration = SyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => throw Exception('Builder failed'),
+      );
+
+      expect(
+        () => migration.buildInstructions(null),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('async deferred migration builder exception is propagated', () async {
+      final migration = AsyncMigration<dynamic, Symbol>.deferred(
+        definedAt: DateTime.utc(2025, 3, 6),
+        builder: (_) => throw Exception('Async builder failed'),
+      );
+
+      await expectLater(
+        () => migration.buildInstructions(null),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('Migration DateTime Handling', () {
+    test('non-UTC datetime throws error', () {
+      expect(
+        () => Mig(
+          definedAt: DateTime(2025, 3, 6), // Local time
+          up: #up,
+          down: #down,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('UTC datetime is preserved exactly', () {
+      final originalTime = DateTime.utc(2025, 3, 6, 14, 30, 45, 123);
+      final migration = Mig(
+        definedAt: originalTime,
+        up: #up,
+        down: #down,
+      );
+
+      expect(migration.definedAt, equals(originalTime));
+      expect(migration.definedAt.isUtc, isTrue);
+    });
+
+    test('microseconds are truncated', () {
+      final originalTime = DateTime.utc(2025, 3, 6, 14, 30, 45, 123, 456);
+      final migration = Mig(
+        definedAt: originalTime,
+        up: #up,
+        down: #down,
+      );
+
+      // Should truncate microseconds but keep milliseconds
+      expect(migration.definedAt.millisecondsSinceEpoch, originalTime.millisecondsSinceEpoch);
+      expect(migration.definedAt.microsecondsSinceEpoch, isNot(originalTime.microsecondsSinceEpoch));
+    });
+
+    test('appliedAt can be null', () {
+      final migration = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        up: #up,
+        down: #down,
+        appliedAt: null,
+      );
+
+      expect(migration.appliedAt, isNull);
+    });
+
+    test('appliedAt is preserved when set', () {
+      final appliedTime = DateTime.utc(2025, 3, 6, 12, 0);
+      final migration = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        up: #up,
+        down: #down,
+        appliedAt: appliedTime,
+      );
+
+      expect(migration.appliedAt, equals(appliedTime));
+    });
+  });
+
+  group('Migration copyWith', () {
+    test('copyWith preserves unspecified fields', () {
+      final original = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        name: 'Original Name',
+        description: 'Original Description',
+        up: #original_up,
+        down: #original_down,
+        alwaysApply: true,
+        appliedAt: DateTime.utc(2025, 3, 6, 12, 0),
+      );
+
+      final copy = original.copyWith(name: 'New Name');
+
+      expect(copy.name, 'New Name');
+      expect(copy.description, original.description);
+      expect(copy.definedAt, original.definedAt);
+      expect(copy.up, original.up);
+      expect(copy.down, original.down);
+      expect(copy.alwaysApply, original.alwaysApply);
+      expect(copy.appliedAt, original.appliedAt);
+    });
+
+    test('copyWith can update all fields', () {
+      final original = Mig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        name: 'Original',
+        up: #original_up,
+        down: #original_down,
+      );
+
+      final newTime = DateTime.utc(2025, 3, 7);
+      final appliedTime = DateTime.utc(2025, 3, 8);
+
+      final copy = original.copyWith(
+        definedAt: newTime,
+        name: 'New Name',
+        description: 'New Description',
+        up: #new_up,
+        down: #new_down,
+        alwaysApply: true,
+        appliedAt: appliedTime,
+      );
+
+      expect(copy.definedAt, newTime);
+      expect(copy.name, 'New Name');
+      expect(copy.description, 'New Description');
+      expect(copy.up, #new_up);
+      expect(copy.down, #new_down);
+      expect(copy.alwaysApply, isTrue);
+      expect(copy.appliedAt, appliedTime);
+    });
+
+    test('async copyWith works the same way', () {
+      final original = AMig(
+        definedAt: DateTime.utc(2025, 3, 6),
+        name: 'Original Name',
+        up: #original_up,
+        down: #original_down,
+      );
+
+      final copy = original.copyWith(description: 'New Description');
+
+      expect(copy.name, original.name);
+      expect(copy.description, 'New Description');
+      expect(copy.definedAt, original.definedAt);
+      expect(copy.up, original.up);
+      expect(copy.down, original.down);
+    });
+  });
+
+  group('Unique edge cases', () {
+    test('migration with extremely old date', () {
+      final migration = Mig(
+        definedAt: DateTime.utc(1970, 1, 1),
+        up: #up,
+        down: #down,
+      );
+
+      expect(migration.definedAt.year, 1970);
+      expect(migration.humanReadableId, '1970-01-01 00:00:00.000Z');
+    });
+
+    test('migration with future date', () {
+      final migration = Mig(
+        definedAt: DateTime.utc(2050, 12, 31, 23, 59, 59),
+        up: #up,
+        down: #down,
+      );
+
+      expect(migration.definedAt.year, 2050);
+      expect(migration.humanReadableId, '2050-12-31 23:59:59.000Z');
+    });
+
+    test('migration set operations work correctly', () {
+      final migration1 = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down);
+      final migration2 = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #different, down: #different);
+      final migration3 = Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down);
+
+      final migrationSet = {migration1, migration2, migration3};
+
+      // Should only contain 2 elements since migration1 and migration2 are equal
+      expect(migrationSet.length, 2);
+      expect(migrationSet.contains(migration1), isTrue);
+      expect(migrationSet.contains(migration2), isTrue);
+      expect(migrationSet.contains(migration3), isTrue);
+    });
+  });
+}

--- a/packages/generic/test/migration_test.dart
+++ b/packages/generic/test/migration_test.dart
@@ -59,4 +59,12 @@ void main() {
     expect(migration1 >= migration1, isTrue);
     expect(migration3 <= migration3, isTrue);
   });
+
+  test('Undo', () {
+    final migration = Migration<Symbol>(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down);
+    final undoMigration = Migration.undo(definedAt: DateTime.utc(2025, 3, 9), migration: migration);
+
+    expect(undoMigration.up, migration.down);
+    expect(undoMigration.down, migration.up);
+  });
 }

--- a/packages/generic/test/migration_test.dart
+++ b/packages/generic/test/migration_test.dart
@@ -59,4 +59,12 @@ void main() {
     expect(migration1 >= migration1, isTrue);
     expect(migration3 <= migration3, isTrue);
   });
+
+  test('Copy with', () {
+    final migration2 = migration.copyWith(up: #newUp, down: #newDown);
+
+    expect(migration2.definedAt, migration.definedAt);
+    expect(migration2.up, #newUp);
+    expect(migration2.down, #newDown);
+  });
 }

--- a/packages/generic/test/migration_test.dart
+++ b/packages/generic/test/migration_test.dart
@@ -1,4 +1,3 @@
-import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
 import 'package:test/test.dart';
 
 import 'logging.dart';

--- a/packages/generic/test/migration_test.dart
+++ b/packages/generic/test/migration_test.dart
@@ -2,13 +2,14 @@ import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_mul
 import 'package:test/test.dart';
 
 import 'logging.dart';
+import 'mock_database.dart';
 
 void main() {
   setUpAll(() {
     setUpLogging();
   });
 
-  final migration = Migration<void>(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null);
+  final migration = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down);
 
   test('UTC', () {
     final a = DateTime(2025, 3, 6);
@@ -19,7 +20,7 @@ void main() {
   });
 
   test('Throw if not UTC', () {
-    expect(() => Migration<void>(definedAt: DateTime(2025, 3, 6), up: null, down: null), throwsA(isA<ArgumentError>()));
+    expect(() => Mig(definedAt: DateTime(2025, 3, 6), up: #up, down: #down), throwsA(isA<ArgumentError>()));
   });
 
   test('DateTime is being preserved', () {
@@ -27,44 +28,36 @@ void main() {
   });
 
   test('Dataclass-ish equality', () {
-    final migration2 = Migration<void>(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null);
-    final migration3 = Migration<void>(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null);
+    final migration2 = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down);
+    final migration3 = Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down);
 
     expect(migration, migration2);
     expect(migration, isNot(migration3));
   });
 
   test('Equality is defined by definedAt', () {
-    final migration = Migration<int>(definedAt: DateTime.utc(2025, 3, 6), up: 0, down: 0);
-    final migration2 = Migration<int>(definedAt: DateTime.utc(2025, 3, 6), up: 1, down: 1);
-    final migration3 = Migration<int>(definedAt: DateTime.utc(2025, 3, 7), up: 0, down: 0);
+    final migration = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #o, down: #o);
+    final migration2 = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #i, down: #i);
+    final migration3 = Mig(definedAt: DateTime.utc(2025, 3, 7), up: #o, down: #o);
 
     expect(migration, migration2);
     expect(migration, isNot(migration3));
   });
 
   test('Hashcode is correctly implemented', () {
-    final migration = Migration<void>(definedAt: DateTime.utc(1970, 0, 1), up: null, down: null);
+    final migration = Mig(definedAt: DateTime.utc(1970, 0, 1), up: #up, down: #down);
 
     expect({migration}, contains(migration));
   });
 
   test('Order is defined by definedAt', () {
-    final migration1 = Migration<void>(definedAt: DateTime.utc(2025, 3, 6), up: null, down: null);
-    final migration2 = Migration<void>(definedAt: DateTime.utc(2025, 3, 7), up: null, down: null);
-    final migration3 = Migration<void>(definedAt: DateTime.utc(2025, 3, 8), up: null, down: null);
+    final migration1 = Mig(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down);
+    final migration2 = Mig(definedAt: DateTime.utc(2025, 3, 7), up: #up, down: #down);
+    final migration3 = Mig(definedAt: DateTime.utc(2025, 3, 8), up: #up, down: #down);
 
     expect(migration1 < migration2, isTrue);
     expect(migration2 > migration1, isTrue);
     expect(migration1 >= migration1, isTrue);
     expect(migration3 <= migration3, isTrue);
-  });
-
-  test('Undo', () {
-    final migration = Migration<Symbol>(definedAt: DateTime.utc(2025, 3, 6), up: #up, down: #down);
-    final undoMigration = Migration.undo(definedAt: DateTime.utc(2025, 3, 9), migration: migration);
-
-    expect(undoMigration.up, migration.down);
-    expect(undoMigration.down, migration.up);
   });
 }

--- a/packages/generic/test/mock_database.dart
+++ b/packages/generic/test/mock_database.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
 import 'package:logging/logging.dart';
 
-typedef Mig = SyncMigration<Null, Symbol>;
-typedef AMig = AsyncMigration<Null, Symbol>;
+typedef Mig = SyncMigration<dynamic, Symbol>;
+typedef AMig = AsyncMigration<dynamic, Symbol>;
 
-class SyncMockDatabase implements SyncDatabase<Null, Symbol> {
-  SyncMockDatabase([List<Mig>? applied])
+class SyncMockDatabase implements SyncDatabase<dynamic, Symbol> {
+  SyncMockDatabase([List<Mig>? applied, this.db])
       : applied = applied ?? List.empty(growable: true),
         appliedForRollback = List.empty(growable: true),
         performedMigrations = List.empty(growable: true),
@@ -15,7 +15,7 @@ class SyncMockDatabase implements SyncDatabase<Null, Symbol> {
         log = Logger('db.mock');
 
   @override
-  final Null db = null;
+  final dynamic db;
 
   final List<Mig> applied;
   final List<Mig> appliedForRollback;
@@ -76,7 +76,7 @@ class SyncMockDatabase implements SyncDatabase<Null, Symbol> {
   }
 }
 
-class AsyncMockDatabase implements AsyncDatabase<Null, Symbol> {
+class AsyncMockDatabase implements AsyncDatabase<dynamic, Symbol> {
   AsyncMockDatabase([List<AMig>? applied])
       : applied = applied ?? List.empty(growable: true),
         appliedForRollback = List.empty(growable: true),
@@ -85,7 +85,7 @@ class AsyncMockDatabase implements AsyncDatabase<Null, Symbol> {
         log = Logger('db.mock');
 
   @override
-  final Null db = null;
+  final dynamic db = null;
 
   final List<AMig> applied;
   final List<AMig> appliedForRollback;

--- a/packages/generic/test/mock_database.dart
+++ b/packages/generic/test/mock_database.dart
@@ -3,20 +3,28 @@ import 'dart:async';
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
 import 'package:logging/logging.dart';
 
-class MockDatabase<T> implements MaybeAsyncDatabase<T> {
-  MockDatabase([List<Migration<T>>? applied])
+typedef Mig = SyncMigration<Null, Symbol>;
+typedef AMig = AsyncMigration<Null, Symbol>;
+
+class SyncMockDatabase implements SyncDatabase<Null, Symbol> {
+  SyncMockDatabase([List<Mig>? applied])
       : applied = applied ?? List.empty(growable: true),
         appliedForRollback = List.empty(growable: true),
         performedMigrations = List.empty(growable: true),
         migrationsTableInitialized = false,
         log = Logger('db.mock');
 
-  final List<Migration<T>> applied;
+  @override
+  final Null db = null;
+
+  final List<Mig> applied;
+  final List<Mig> appliedForRollback;
   final Logger log;
   bool migrationsTableInitialized;
+  List<Symbol> performedMigrations;
 
   @override
-  FutureOr<void> initializeMigrationsTable() {
+  void initializeMigrationsTable() {
     migrationsTableInitialized = true;
   }
 
@@ -24,25 +32,23 @@ class MockDatabase<T> implements MaybeAsyncDatabase<T> {
   bool isMigrationsTableInitialized() => migrationsTableInitialized;
 
   @override
-  FutureOr<void> performMigration(T migration) {
+  void performMigration(Symbol migration) {
     log.info('performing migration', migration);
     performedMigrations.add(migration);
   }
 
-  List<T> performedMigrations;
-
   @override
-  dynamic retrieveAllMigrations() {
+  Iterator<Mig> retrieveAllMigrations() {
     return applied.iterator;
   }
 
   @override
-  FutureOr<void> storeMigrations(List<Migration<T>> migration) {
+  void storeMigrations(List<Mig> migration) {
     applied.addAll(migration);
   }
 
   @override
-  FutureOr<void> removeMigrations(List<Migration<T>> migrations) {
+  void removeMigrations(List<Mig> migrations) {
     for (final migration in migrations) {
       log.fine('removing migration ${migration.humanReadableId} from database...');
       if (!applied.remove(migration)) {
@@ -51,41 +57,91 @@ class MockDatabase<T> implements MaybeAsyncDatabase<T> {
     }
   }
 
-  final List<Migration<T>> appliedForRollback;
-
   @override
-  FutureOr<void> beginTransaction() {
+  void beginTransaction() {
     appliedForRollback.clear();
     appliedForRollback.addAll(applied);
   }
 
   @override
-  FutureOr<void> commitTransaction() {
+  void commitTransaction() {
     appliedForRollback.clear();
   }
 
   @override
-  FutureOr<void> rollbackTransaction() {
+  void rollbackTransaction() {
     applied.clear();
     applied.addAll(appliedForRollback);
     appliedForRollback.clear();
   }
 }
 
-class SyncMockDatabase<T> extends MockDatabase<T> implements SyncDatabase<T> {
-  SyncMockDatabase([super.applied]);
+class AsyncMockDatabase implements AsyncDatabase<Null, Symbol> {
+  AsyncMockDatabase([List<AMig>? applied])
+      : applied = applied ?? List.empty(growable: true),
+        appliedForRollback = List.empty(growable: true),
+        performedMigrations = List.empty(growable: true),
+        migrationsTableInitialized = false,
+        log = Logger('db.mock');
 
   @override
-  Iterator<Migration<T>> retrieveAllMigrations() {
-    return applied.iterator;
+  final Null db = null;
+
+  final List<AMig> applied;
+  final List<AMig> appliedForRollback;
+  final Logger log;
+  bool migrationsTableInitialized;
+  List<Symbol> performedMigrations;
+
+  @override
+  Future<void> initializeMigrationsTable() async {
+    migrationsTableInitialized = true;
   }
-}
-
-class AsyncMockDatabase<T> extends MockDatabase<T> implements AsyncDatabase<T> {
-  AsyncMockDatabase([super.applied]);
 
   @override
-  Stream<Migration<T>> retrieveAllMigrations() {
+  bool isMigrationsTableInitialized() => migrationsTableInitialized;
+
+  @override
+  Future<void> performMigration(Symbol migration) async {
+    log.info('performing migration', migration);
+    performedMigrations.add(migration);
+  }
+
+  @override
+  Stream<AMig> retrieveAllMigrations() {
     return Stream.fromIterable(applied);
+  }
+
+  @override
+  Future<void> storeMigrations(List<AMig> migration) async {
+    applied.addAll(migration);
+  }
+
+  @override
+  Future<void> removeMigrations(List<AMig> migrations) async {
+    for (final migration in migrations) {
+      log.fine('removing migration ${migration.humanReadableId} from database...');
+      if (!applied.remove(migration)) {
+        throw StateError('migration could not be removed: not found in database');
+      }
+    }
+  }
+
+  @override
+  Future<void> beginTransaction() async {
+    appliedForRollback.clear();
+    appliedForRollback.addAll(applied);
+  }
+
+  @override
+  Future<void> commitTransaction() async {
+    appliedForRollback.clear();
+  }
+
+  @override
+  Future<void> rollbackTransaction() async {
+    applied.clear();
+    applied.addAll(appliedForRollback);
+    appliedForRollback.clear();
   }
 }

--- a/packages/generic/test/mock_database.dart
+++ b/packages/generic/test/mock_database.dart
@@ -32,7 +32,7 @@ class SyncMockDatabase implements SyncDatabase<Null, Symbol> {
   bool isMigrationsTableInitialized() => migrationsTableInitialized;
 
   @override
-  void performMigration(Symbol migration) {
+  void executeInstructions(Symbol migration) {
     log.info('performing migration', migration);
     performedMigrations.add(migration);
   }
@@ -102,7 +102,7 @@ class AsyncMockDatabase implements AsyncDatabase<Null, Symbol> {
   bool isMigrationsTableInitialized() => migrationsTableInitialized;
 
   @override
-  Future<void> performMigration(Symbol migration) async {
+  Future<void> executeInstructions(Symbol migration) async {
     log.info('performing migration', migration);
     performedMigrations.add(migration);
   }

--- a/packages/generic/test/mock_database.dart
+++ b/packages/generic/test/mock_database.dart
@@ -7,6 +7,7 @@ class MockDatabase<T> implements MaybeAsyncDatabase<T> {
   MockDatabase([List<Migration<T>>? applied])
       : applied = applied ?? List.empty(growable: true),
         appliedForRollback = List.empty(growable: true),
+        performedMigrations = List.empty(growable: true),
         migrationsTableInitialized = false,
         log = Logger('db.mock');
 
@@ -25,7 +26,10 @@ class MockDatabase<T> implements MaybeAsyncDatabase<T> {
   @override
   FutureOr<void> performMigration(T migration) {
     log.info('performing migration', migration);
+    performedMigrations.add(migration);
   }
+
+  List<T> performedMigrations;
 
   @override
   dynamic retrieveAllMigrations() {

--- a/packages/sqflite/example/sqflite_migrations_with_multiverse_time_travel_example.dart
+++ b/packages/sqflite/example/sqflite_migrations_with_multiverse_time_travel_example.dart
@@ -23,13 +23,13 @@ Future<void> main() async {
   sqfliteFfiInit();
 
   var databaseFactory = databaseFactoryFfi;
-  var db = await databaseFactory.openDatabase(inMemoryDatabasePath);
 
-  await SqfliteDatabase(db).migrate(migrations);
+  final wrapper = SqfliteDatabase((_) => databaseFactory.openDatabase(inMemoryDatabasePath));
+  await wrapper.migrate(migrations);
 
-  for (final row in await db.query('users')) {
+  for (final row in await (await wrapper.db).query('users')) {
     print(row);
   }
 
-  await db.close();
+  await (await wrapper.db).close();
 }

--- a/packages/sqflite/lib/sqflite_migrations_with_multiverse_time_travel.dart
+++ b/packages/sqflite/lib/sqflite_migrations_with_multiverse_time_travel.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' as p;
+import 'package:sqflite_common/sqflite.dart';
 
 export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart'
     show AsyncMigrateExt;
@@ -9,7 +10,7 @@ export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_mul
 export 'src/database.dart';
 export 'src/transaction.dart';
 
-/// Typedef for [p.Migration] of [String].
+/// Typedef for [p.AsyncMigration] of [String].
 ///
 /// {@macro dmwmt.migration}
-typedef Migration = p.Migration<String>;
+typedef Migration = p.AsyncMigration<Database, String>;

--- a/packages/sqflite/lib/sqflite_migrations_with_multiverse_time_travel.dart
+++ b/packages/sqflite/lib/sqflite_migrations_with_multiverse_time_travel.dart
@@ -1,7 +1,15 @@
 /// A library for managing SQLite database migrations with multiverse time travel.
 library;
 
+import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' as p;
+
 export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart'
-    show Migration, AsyncMigrateExt;
+    show AsyncMigrateExt;
 
 export 'src/database.dart';
+export 'src/transaction.dart';
+
+/// Typedef for [p.Migration] of [String].
+/// 
+/// {@macro dmwmt.migration}
+typedef Migration = p.Migration<String>;

--- a/packages/sqflite/lib/sqflite_migrations_with_multiverse_time_travel.dart
+++ b/packages/sqflite/lib/sqflite_migrations_with_multiverse_time_travel.dart
@@ -10,6 +10,6 @@ export 'src/database.dart';
 export 'src/transaction.dart';
 
 /// Typedef for [p.Migration] of [String].
-/// 
+///
 /// {@macro dmwmt.migration}
 typedef Migration = p.Migration<String>;

--- a/packages/sqflite/lib/src/database.dart
+++ b/packages/sqflite/lib/src/database.dart
@@ -12,7 +12,7 @@ class SqfliteDatabase implements AsyncDatabase<String> {
   });
 
   final Database _db;
-  
+
   /// Responsible for handling transactions
   final Transactor transactor;
 

--- a/packages/sqflite/lib/src/database.dart
+++ b/packages/sqflite/lib/src/database.dart
@@ -50,8 +50,8 @@ CREATE TABLE IF NOT EXISTS migrations (
   }
 
   @override
-  Future<void> performMigration(String migration) {
-    return db.execute(migration);
+  Future<void> executeInstructions(String sql) {
+    return db.execute(sql);
   }
 
   @override

--- a/packages/sqflite/lib/src/transaction.dart
+++ b/packages/sqflite/lib/src/transaction.dart
@@ -96,7 +96,6 @@ class BackupTransactionDelegate extends Transactor {
   Future<void> rollback(Database db) async {
     await db.close();
     if (db.path == ":memory:") return;
-    await _backupFile.copy(_dbFile.path);
-    await _backupFile.delete();
+    await _backupFile.rename(_dbFile.path);
   }
 }

--- a/packages/sqflite/lib/src/transaction.dart
+++ b/packages/sqflite/lib/src/transaction.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:sqflite_common/sqflite.dart';
+
+/// A delegate for handling database transactions.
+///
+/// _Transactions_ being a sequence of operations that can be rolled back as a single unit.
+abstract class Transactor {
+  /// const constructor for implementations of [Transactor].
+  const Transactor();
+
+  /// Begins a transaction on the provided [db].
+  Future<void> begin(Database db);
+
+  /// Commits the transaction on the provided [db].
+  Future<void> commit(Database db);
+
+  /// Rolls back the transaction on the provided [db].
+  Future<void> rollback(Database db);
+}
+
+/// A [Transactor] that does not perform any transaction.
+///
+/// This is only useful for testing purposes and should not be used in production code.
+class NoTransactionDelegate extends Transactor {
+  /// Creates a [NoTransactionDelegate] that does not perform any transaction.
+  const NoTransactionDelegate();
+
+  @override
+  Future<void> begin(Database db) => Future.value();
+
+  @override
+  Future<void> commit(Database db) => Future.value();
+
+  @override
+  Future<void> rollback(Database db) => Future.value();
+}
+
+/// A [Transactor] that uses standard SQL transactions.
+class TransactionDelegate implements Transactor {
+  /// Creates a [TransactionDelegate] that uses standard SQL transactions.
+  const TransactionDelegate();
+
+  @override
+  Future<void> begin(Database db) => db.execute('BEGIN TRANSACTION');
+
+  @override
+  Future<void> commit(Database db) => db.execute('COMMIT TRANSACTION');
+
+  @override
+  Future<void> rollback(Database db) => db.execute('ROLLBACK TRANSACTION');
+}
+
+/// A [Transactor] that creates a backup of the database that can be restored in case of a rollback.
+///
+/// Note that after migration it will **close** the database,
+/// so you will need to reopen it if you want to continue using it.
+class BackupTransactionDelegate implements Transactor {
+  /// Creates a [BackupTransactionDelegate] that creates a backup of the database.
+  ///
+  /// The [backupFileName] is the name of the backup file that will be created in the same directory as the database file.
+  BackupTransactionDelegate({
+    this.backupFileName = 'backup.db',
+  });
+
+  /// The name of the backup file that will be created in the same directory as the database file.
+  final String backupFileName;
+  late final File _dbFile;
+  late final File _backupFile;
+
+  @override
+  Future<void> begin(Database db) async {
+    if (db.path == ":memory:") {
+      return db.execute("VACUUM INTO '$backupFileName';");
+    }
+    _dbFile = File(db.path);
+    _backupFile = File.fromUri(_dbFile.uri.replace(
+        pathSegments: _dbFile.uri.pathSegments.take(_dbFile.uri.pathSegments.length - 2).followedBy([backupFileName])));
+    if (await _backupFile.exists()) {
+      await _backupFile.delete();
+    }
+
+    return db.execute("VACUUM INTO '${_backupFile.uri.toFilePath()}';");
+  }
+
+  @override
+  Future<void> commit(Database db) {
+    // Close it here too despite not being necessary,
+    // to make sure that user code is able to handle
+    // the rollback case correctly, where there
+    // is no choice but to close the database.
+    return db.close();
+  }
+
+  @override
+  Future<void> rollback(Database db) async {
+    await db.close();
+    if (db.path == ":memory:") return;
+    await _backupFile.copy(_dbFile.path);
+  }
+}

--- a/packages/sqflite/lib/src/transaction.dart
+++ b/packages/sqflite/lib/src/transaction.dart
@@ -70,12 +70,12 @@ class BackupTransactionDelegate extends Transactor {
 
   @override
   Future<void> begin(Database db) async {
-    if (db.path == ":memory:") {
-      return db.execute("VACUUM INTO '$backupFileName';");
+    if (db.path.isEmpty || db.path == ':memory:') {
+      _backupFile = File(backupFileName);
+    } else {
+      _dbFile = File(db.path);
+      _backupFile = File('${_dbFile.parent.path}/$backupFileName');
     }
-    _dbFile = File(db.path);
-    _backupFile = File.fromUri(_dbFile.uri.replace(
-        pathSegments: _dbFile.uri.pathSegments.take(_dbFile.uri.pathSegments.length - 2).followedBy([backupFileName])));
     if (await _backupFile.exists()) {
       await _backupFile.delete();
     }
@@ -95,7 +95,7 @@ class BackupTransactionDelegate extends Transactor {
   @override
   Future<void> rollback(Database db) async {
     await db.close();
-    if (db.path == ":memory:") return;
+    if (db.path.isEmpty || db.path == ':memory:') return;
     await _backupFile.rename(_dbFile.path);
   }
 }

--- a/packages/sqflite/lib/src/transaction.dart
+++ b/packages/sqflite/lib/src/transaction.dart
@@ -97,5 +97,6 @@ class BackupTransactionDelegate extends Transactor {
     await db.close();
     if (db.path == ":memory:") return;
     await _backupFile.copy(_dbFile.path);
+    await _backupFile.delete();
   }
 }

--- a/packages/sqflite/lib/src/transaction.dart
+++ b/packages/sqflite/lib/src/transaction.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:sqflite_common/sqflite.dart';
 import 'package:sqflite_migrations_with_multiverse_time_travel/sqflite_migrations_with_multiverse_time_travel.dart';
 
 /// A delegate for handling database transactions.

--- a/packages/sqflite/pubspec.yaml
+++ b/packages/sqflite/pubspec.yaml
@@ -15,9 +15,11 @@ resolution: workspace
 # Add regular dependencies here.
 dependencies:
   db_migrations_with_multiverse_time_travel: ^1.1.0
+  meta: ^1.17.0
   sqflite_common: ^2.4.1
 
 dev_dependencies:
   lints: ^5.0.0
   test: ^1.24.0
   sqflite_common_ffi: ^2.2.1
+  mutex: ^3.1.0

--- a/packages/sqflite/pubspec.yaml
+++ b/packages/sqflite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqflite_migrations_with_multiverse_time_travel
 description: Runs database migrations for apps using sqflite. Check out different branches during development without having to reset the db.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/benthillerkus/db_migrations_with_multiverse_time_travel
 issue_tracker: https://github.com/benthillerkus/db_migrations_with_multiverse_time_travel/issues
 topics: ["database", "migration", "sqflite"]
@@ -14,7 +14,7 @@ resolution: workspace
 
 # Add regular dependencies here.
 dependencies:
-  db_migrations_with_multiverse_time_travel: ^1.1.0
+  db_migrations_with_multiverse_time_travel: ^2.0.0
   meta: ^1.3.0
   sqflite_common: ^2.4.1
 

--- a/packages/sqflite/pubspec.yaml
+++ b/packages/sqflite/pubspec.yaml
@@ -15,7 +15,7 @@ resolution: workspace
 # Add regular dependencies here.
 dependencies:
   db_migrations_with_multiverse_time_travel: ^1.1.0
-  meta: ^1.17.0
+  meta: ^1.3.0
   sqflite_common: ^2.4.1
 
 dev_dependencies:

--- a/packages/sqflite/test/backup_test.dart
+++ b/packages/sqflite/test/backup_test.dart
@@ -33,14 +33,14 @@ void main() {
     mutex.release();
   });
 
-  test("Regular stuff works", () async {
+  test("Regular stuff works", retry: 2, () async {
     final migrations = [
       Migration(definedAt: DateTime.utc(2000, 11, 3), up: 'select(0)', down: 'select(0)'),
     ];
     await wrapper.migrate(migrations);
   });
 
-  test("Reopen after commit", () async {
+  test("Reopen after commit", retry: 2, () async {
     final migrations = [
       Migration(definedAt: DateTime.utc(2003, 1, 5, 4), up: '''
 create table users (
@@ -65,7 +65,7 @@ delete from users;
     await expectLater(db.query('users'), completion(hasLength(2)));
   });
 
-  test("Rollback", () async {
+  test("Rollback", retry: 2, () async {
     final migrations = [
       Migration(definedAt: DateTime.utc(2005), up: '''
 create table farmers(

--- a/packages/sqflite/test/backup_test.dart
+++ b/packages/sqflite/test/backup_test.dart
@@ -33,14 +33,14 @@ void main() {
     mutex.release();
   });
 
-  test("Regular stuff works", retry: 2, () async {
+  test("Regular stuff works", retry: 3, () async {
     final migrations = [
       Migration(definedAt: DateTime.utc(2000, 11, 3), up: 'select(0)', down: 'select(0)'),
     ];
     await wrapper.migrate(migrations);
   });
 
-  test("Reopen after commit", retry: 2, () async {
+  test("Reopen after commit", retry: 3, () async {
     final migrations = [
       Migration(definedAt: DateTime.utc(2003, 1, 5, 4), up: '''
 create table users (
@@ -65,7 +65,7 @@ delete from users;
     await expectLater(db.query('users'), completion(hasLength(2)));
   });
 
-  test("Rollback", retry: 2, () async {
+  test("Rollback", retry: 3, () async {
     final migrations = [
       Migration(definedAt: DateTime.utc(2005), up: '''
 create table farmers(

--- a/packages/sqflite/test/backup_test.dart
+++ b/packages/sqflite/test/backup_test.dart
@@ -6,6 +6,7 @@ import 'package:mutex/mutex.dart';
 void main() {
   late Database db;
   late SqfliteDatabase wrapper;
+
   /// Prevents concurrency issues with file creation / deletion
   final mutex = Mutex();
 

--- a/packages/sqflite/test/backup_test.dart
+++ b/packages/sqflite/test/backup_test.dart
@@ -3,12 +3,12 @@ import 'package:sqflite_migrations_with_multiverse_time_travel/sqflite_migration
 import 'package:test/test.dart';
 import 'package:mutex/mutex.dart';
 
+/// Prevents concurrency issues with file creation / deletion
+final mutex = Mutex();
+
 void main() {
   late Database db;
   late SqfliteDatabase wrapper;
-
-  /// Prevents concurrency issues with file creation / deletion
-  final mutex = Mutex();
 
   setUpAll(() {
     sqfliteFfiInit();

--- a/packages/sqflite/test/backup_test.dart
+++ b/packages/sqflite/test/backup_test.dart
@@ -1,0 +1,145 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:sqflite_migrations_with_multiverse_time_travel/sqflite_migrations_with_multiverse_time_travel.dart';
+import 'package:test/test.dart';
+import 'package:mutex/mutex.dart';
+
+void main() {
+  late Database db;
+  late SqfliteDatabase wrapper;
+  /// Prevents concurrency issues with file creation / deletion
+  final mutex = Mutex();
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    await mutex.acquire();
+    if (await databaseExists("test.db")) {
+      await deleteDatabase("test.db");
+    }
+    db = await openDatabase("test.db");
+    wrapper = SqfliteDatabase(db, transactor: BackupTransactionDelegate());
+    await wrapper.initializeMigrationsTable();
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await databaseExists(db.path)) {
+      await deleteDatabase(db.path);
+    }
+    mutex.release();
+  });
+
+  test("Regular stuff works", () async {
+    final migrations = [
+      Migration(definedAt: DateTime.utc(2000, 11, 3), up: 'select(0)', down: 'select(0)'),
+    ];
+    await wrapper.migrate(migrations);
+  });
+
+  test("Reopen after commit", () async {
+    final migrations = [
+      Migration(definedAt: DateTime.utc(2003, 1, 5, 4), up: '''
+create table users (
+  id integer primary key autoincrement,
+  name text
+);
+''', down: '''
+drop table users;
+'''),
+      Migration(definedAt: DateTime.utc(2007), up: '''
+insert into users (name) values ('peter'), ('hans');
+''', down: '''
+delete from users;
+''')
+    ];
+    await wrapper.migrate(migrations);
+
+    expect(db.isOpen, isFalse);
+
+    db = await openDatabase(db.path);
+
+    await expectLater(db.query('users'), completion(hasLength(2)));
+  });
+
+  test("Rollback", () async {
+    final migrations = [
+      Migration(definedAt: DateTime.utc(2005), up: '''
+create table farmers(
+  id integer primary key autoincrement,
+  name text
+);
+
+create table sheep(
+  id integer primary key autoincrement,
+  name text,
+  farmer_id integer,
+  foreign key (farmer_id) references farmers(id)
+);
+''', down: '''
+drop table sheep;
+drop table farmers;
+'''),
+      Migration(
+        definedAt: DateTime.utc(2006),
+        alwaysApply: true,
+        name: 'check foreign keys',
+        up: "pragma foreign_keys=1;",
+        down: "pragma foreign_keys=0;",
+      ),
+      Migration(definedAt: DateTime.utc(2007), up: '''
+insert into farmers ('id', 'name') values (0, 'bob');
+insert into sheep ('name', 'farmer_id') values ('shaun', 0);
+''', down: '''
+delete from sheep where 'name'='shaun';
+delete from farmers where 'name'='bob';
+'''),
+      Migration(
+        definedAt: DateTime.utc(2008),
+        name: 'add hank',
+        up: "insert into sheep ('name', 'farmer_id') values ('hank', 0);",
+        down: "delete from sheep where name = 'hank';",
+      ),
+    ];
+
+    await wrapper.migrate(migrations);
+
+    db = await openDatabase(db.path);
+    wrapper = SqfliteDatabase(db, transactor: BackupTransactionDelegate());
+
+    await expectLater(db.query('sheep'), completion(hasLength(2)));
+    await expectLater(db.query('sheep', where: "name = 'hank'"), completion(hasLength(1)));
+
+    final migrations2 = [
+      Migration.undo(definedAt: DateTime.utc(2010), migration: migrations.last),
+      Migration(
+        definedAt: DateTime.utc(2011),
+        name: 'faulty migration',
+        up: 'delete from farmers;',
+        down: 'select(0);',
+      )
+    ];
+
+    await expectLater(wrapper.migrate(migrations + migrations2), throwsA(anything));
+
+    db = await openDatabase(db.path);
+    wrapper = SqfliteDatabase(db, transactor: BackupTransactionDelegate());
+
+    await expectLater(wrapper.retrieveAllMigrations().last, completion(migrations.last));
+    await expectLater(db.query('sheep'), completion(hasLength(2)));
+    await expectLater(db.query('sheep', where: "name = 'hank'"), completion(hasLength(1)));
+
+    // And just to make sure that the deletion would have worked, if not for the faulty migration:
+
+    await wrapper.migrate(migrations + [migrations2.first]);
+
+    db = await openDatabase(db.path);
+    wrapper = SqfliteDatabase(db, transactor: BackupTransactionDelegate());
+
+    await expectLater(wrapper.retrieveAllMigrations().last, completion(migrations2.first));
+    await expectLater(db.query('sheep'), completion(hasLength(1)));
+    await expectLater(db.query('sheep', where: "name = 'hank'"), completion(isEmpty));
+  });
+}

--- a/packages/sqflite/test/backup_test.dart
+++ b/packages/sqflite/test/backup_test.dart
@@ -114,7 +114,12 @@ delete from farmers where 'name'='bob';
     await expectLater(db.query('sheep', where: "name = 'hank'"), completion(hasLength(1)));
 
     final migrations2 = [
-      Migration.undo(definedAt: DateTime.utc(2010), migration: migrations.last),
+      Migration(
+        definedAt: DateTime.utc(2009),
+        name: 'remove hank',
+        up: "delete from sheep where name = 'hank';",
+        down: "insert into sheep ('name', 'farmer_id') values ('hank', 0);",
+      ),
       Migration(
         definedAt: DateTime.utc(2011),
         name: 'faulty migration',

--- a/packages/sqflite/test/wrapper_test.dart
+++ b/packages/sqflite/test/wrapper_test.dart
@@ -36,7 +36,7 @@ void main() {
 
     group('Insert migration', () {
       test('Insertion', () async {
-        final migration = Migration<String>(
+        final migration = Migration(
           definedAt: DateTime.utc(2021, 1, 1),
           name: 'test',
           description: 'test',
@@ -54,6 +54,122 @@ void main() {
         expect(result[0], containsPair('applied_at', migration.appliedAt!.millisecondsSinceEpoch));
         expect(result[0], containsPair('up', migration.up));
         expect(result[0], containsPair('down', migration.down));
+      });
+    });
+
+    group('Always apply', () {
+      final migrations = <Migration>[
+        Migration(name: 'Create users and notes tables', definedAt: DateTime.utc(2025, 6, 23), up: '''
+CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);
+CREATE TABLE notes (id INTEGER PRIMARY KEY AUTOINCREMENT, note TEXT, user_id INTEGER, FOREIGN KEY (user_id) REFERENCES users (id));
+''', down: '''
+DROP TABLE notes;
+DROP TABLE users;
+'''),
+        Migration(name: 'Insert users', definedAt: DateTime.utc(2025, 6, 23, 12, 0), up: '''
+INSERT INTO users (name) VALUES ('Alice'), ('Bob'), ('Charlie');
+''', down: '''
+DELETE FROM users WHERE name IN ('Alice', 'Bob', 'Charlie');
+'''),
+        Migration(name: 'Insert notes', definedAt: DateTime.utc(2025, 6, 23, 12, 1), up: '''
+INSERT INTO notes (note, user_id) VALUES ('is cool', 1), ('sucks', 2), ('is awesome', 1);
+''', down: '''
+DELETE FROM notes WHERE note IN ('is cool', 'sucks', 'is awesome');
+'''),
+      ];
+
+      test('Basic', () async {
+        await expectLater(() => db.query('notes'), throwsA(anything),
+            reason: 'Database should not have notes table before migration');
+
+        await wrapper.migrate(migrations);
+
+        final result = await db.query('notes');
+        expect(result, hasLength(3));
+      });
+
+      group("Insert orphan", () {
+        test("Foreign keys aren't enforced by default", () async {
+          await wrapper.migrate(migrations);
+
+          // Insert a note with a non-existing user_id
+          await db.execute('INSERT INTO notes (note, user_id) VALUES (?, ?)', ['orphan note', 999]);
+
+          final result = await db.query('notes');
+          expect(result, hasLength(4)); // Should include the orphan note
+        });
+
+        test("Throws when foreign keys are enforced", () async {
+          await wrapper.migrate(migrations);
+          await db.execute('PRAGMA foreign_keys = ON');
+
+          await expectLater(
+            () => db.execute('INSERT INTO notes (note, user_id) VALUES (?, ?)', ['orphan note', 999]),
+            throwsA(anything),
+            reason: 'Should throw when trying to insert a note with a non-existing user_id',
+          );
+        });
+      });
+
+      group("PRAGMA foreign_keys", () {
+        Matcher foreignKeysEnabled = isA<List<Map<String, dynamic>>>().having(
+          (it) => it.first['foreign_keys'],
+          'foreign_keys',
+          equals(1),
+        );
+
+        Matcher foreignKeysDisabled = isA<List<Map<String, dynamic>>>().having(
+          (it) => it.first['foreign_keys'],
+          'foreign_keys',
+          equals(0),
+        );
+
+        test("Setting and reading works", () async {
+          await expectLater(db.rawQuery("PRAGMA foreign_keys"), completion(foreignKeysDisabled));
+          await db.execute('PRAGMA foreign_keys = ON');
+          await expectLater(db.rawQuery("PRAGMA foreign_keys"), completion(foreignKeysEnabled));
+          await db.execute('PRAGMA foreign_keys = OFF');
+          await expectLater(db.rawQuery("PRAGMA foreign_keys"), completion(foreignKeysDisabled));
+        });
+
+        test("Noops inside of a transaction", () async {
+          await db.transaction((txn) async {
+            await expectLater(txn.rawQuery("PRAGMA foreign_keys"), completion(foreignKeysDisabled));
+            await txn.execute('PRAGMA foreign_keys = ON');
+            await expectLater(txn.rawQuery("PRAGMA foreign_keys"), completion(foreignKeysDisabled));
+          });
+          await db.execute('PRAGMA foreign_keys = ON');
+          await db.transaction((txn) async {
+            await expectLater(txn.rawQuery("PRAGMA foreign_keys"), completion(foreignKeysEnabled));
+            await txn.execute('PRAGMA foreign_keys = OFF');
+            await expectLater(txn.rawQuery("PRAGMA foreign_keys"), completion(foreignKeysEnabled));
+          });
+        });
+      });
+
+      test('With always apply', () async {
+        wrapper = SqfliteDatabase(db, transactor: NoTransactionDelegate());
+        final migrations2 = <Migration>[
+          Migration(name: 'Make orphan note', definedAt: DateTime.utc(2025, 6, 23, 12, 2), up: '''
+INSERT INTO notes (note, user_id) VALUES ('orphan note', 999);
+''', down: '''
+DELETE FROM notes WHERE note = 'orphan note' AND user_id = 999;
+'''),
+          Migration(
+              name: 'Enforce foreign keys',
+              alwaysApply: true,
+              definedAt: DateTime.utc(2025, 6, 23, 12, 3),
+              up: '''
+PRAGMA foreign_keys = ON;
+''',
+              down: '''
+PRAGMA foreign_keys = OFF;
+'''),
+        ];
+
+        await wrapper.migrate(migrations + migrations2);
+
+        await expectLater(() => db.delete('users'), throwsA(anything));
       });
     });
   });

--- a/packages/sqflite/test/wrapper_test.dart
+++ b/packages/sqflite/test/wrapper_test.dart
@@ -44,7 +44,7 @@ void main() {
           up: 'CREATE TABLE tbl (a TEXT)',
           down: 'DROP TABLE tbl',
         );
-        await wrapper.storeMigrations([migration]);
+        await wrapper.storeMigrations([migration].cast());
 
         final result = await db.query('migrations');
         expect(result, hasLength(1));

--- a/packages/sqflite/test/wrapper_test.dart
+++ b/packages/sqflite/test/wrapper_test.dart
@@ -1,3 +1,12 @@
+// LLM generated code
+//
+// This is just intended to "harden" the test suite
+// and entrench current behavior.
+//
+// Since there is no intention behind these
+// they can just be removed and regenerated
+// if they conflict with future changes.
+
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sqflite_migrations_with_multiverse_time_travel/sqflite_migrations_with_multiverse_time_travel.dart';
 import 'package:test/test.dart';
@@ -43,7 +52,7 @@ void main() {
           up: 'CREATE TABLE tbl (a TEXT)',
           down: 'DROP TABLE tbl',
         );
-        await wrapper.storeMigrations([migration].cast());
+        await wrapper.storeMigrations([migration]);
 
         final db = await wrapper.db;
         final result = await db.query('migrations');

--- a/packages/sqlite3/example/sqlite3_migrations_with_multiverse_time_travel_example.dart
+++ b/packages/sqlite3/example/sqlite3_migrations_with_multiverse_time_travel_example.dart
@@ -26,7 +26,7 @@ void main() {
   open.overrideFor(OperatingSystem.windows, () => DynamicLibrary.open('winsqlite3.dll'));
   final db = sqlite3.openInMemory();
 
-  Sqlite3Database(db).migrate(migrations);
+  Sqlite3Database((_) => db).migrate(migrations);
 
   for (final row in db.select('select * from users').rows) {
     print(row);

--- a/packages/sqlite3/lib/sqlite3_migrations_with_multiverse_time_travel.dart
+++ b/packages/sqlite3/lib/sqlite3_migrations_with_multiverse_time_travel.dart
@@ -1,10 +1,11 @@
 /// A library for managing SQLite database migrations with multiverse time travel.
 library;
 
+import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' as p;
+import 'package:sqlite3/common.dart';
+
 export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart'
     show SyncMigrateExt;
-
-import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' as p;
 
 export 'src/database.dart';
 export 'src/transaction.dart';
@@ -12,4 +13,4 @@ export 'src/transaction.dart';
 /// Typedef for [p.Migration] over [String].
 ///
 /// {@macro dmwmt.migration}
-typedef Migration = p.Migration<String>;
+typedef Migration = p.SyncMigration<CommonDatabase, String>;

--- a/packages/sqlite3/lib/sqlite3_migrations_with_multiverse_time_travel.dart
+++ b/packages/sqlite3/lib/sqlite3_migrations_with_multiverse_time_travel.dart
@@ -1,7 +1,13 @@
 /// A library for managing SQLite database migrations with multiverse time travel.
 library;
 
-export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart'
-    show Migration, SyncMigrateExt;
+export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' show SyncMigrateExt;
+
+import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' as p;
 
 export 'src/database.dart';
+
+/// Typedef for [p.Migration] over [String].
+/// 
+/// {@macro dmwmt.migration}
+typedef Migration = p.Migration<String>;

--- a/packages/sqlite3/lib/sqlite3_migrations_with_multiverse_time_travel.dart
+++ b/packages/sqlite3/lib/sqlite3_migrations_with_multiverse_time_travel.dart
@@ -7,6 +7,7 @@ export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_mul
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' as p;
 
 export 'src/database.dart';
+export 'src/transaction.dart';
 
 /// Typedef for [p.Migration] over [String].
 ///

--- a/packages/sqlite3/lib/sqlite3_migrations_with_multiverse_time_travel.dart
+++ b/packages/sqlite3/lib/sqlite3_migrations_with_multiverse_time_travel.dart
@@ -1,13 +1,14 @@
 /// A library for managing SQLite database migrations with multiverse time travel.
 library;
 
-export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' show SyncMigrateExt;
+export 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart'
+    show SyncMigrateExt;
 
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart' as p;
 
 export 'src/database.dart';
 
 /// Typedef for [p.Migration] over [String].
-/// 
+///
 /// {@macro dmwmt.migration}
 typedef Migration = p.Migration<String>;

--- a/packages/sqlite3/lib/src/database.dart
+++ b/packages/sqlite3/lib/src/database.dart
@@ -108,9 +108,8 @@ CREATE TABLE IF NOT EXISTS migrations (
   }
 
   @override
-  @internal
-  void performMigration(String migration) {
-    db.execute(migration);
+  void executeInstructions(String sql) {
+    db.execute(sql);
   }
 
   @override

--- a/packages/sqlite3/lib/src/database.dart
+++ b/packages/sqlite3/lib/src/database.dart
@@ -5,21 +5,22 @@ import 'package:sqlite3/common.dart';
 import 'transaction.dart';
 
 /// A [SyncDatabase] implementation for SQLite3.
-class Sqlite3Database implements SyncDatabase<String> {
+class Sqlite3Database implements SyncDatabase<CommonDatabase, String> {
   /// Creates a new [Sqlite3Database] instance.
   const Sqlite3Database(
-    this._db, {
+    this.db, {
     this.transactor = const TransactionDelegate(),
   });
 
-  final CommonDatabase _db;
+  @override
+  final CommonDatabase db;
 
   /// Responsible for handling transactions
   final Transactor transactor;
 
   @override
   void initializeMigrationsTable() {
-    _db.execute('''
+    db.execute('''
 CREATE TABLE IF NOT EXISTS migrations (
   defined_at INTEGER PRIMARY KEY,
   name TEXT,
@@ -32,7 +33,7 @@ CREATE TABLE IF NOT EXISTS migrations (
 
   @override
   bool isMigrationsTableInitialized() {
-    final result = _db.select(
+    final result = db.select(
       '''SELECT name FROM sqlite_master WHERE type='table' AND name='migrations' LIMIT 1''',
     );
     return result.isNotEmpty;
@@ -40,14 +41,14 @@ CREATE TABLE IF NOT EXISTS migrations (
 
   @override
   @internal
-  Iterator<Migration<String>> retrieveAllMigrations() {
-    return _db
+  Iterator<SyncMigration<CommonDatabase, String>> retrieveAllMigrations() {
+    return db
         .select('''SELECT * FROM migrations ORDER BY defined_at ASC''')
         .rows
         .map((row) {
           final [definedAt, name, description, appliedAt, up, down] = row;
 
-          return Migration<String>(
+          return SyncMigration<CommonDatabase, String>(
             definedAt: DateTime.fromMillisecondsSinceEpoch(definedAt as int, isUtc: true),
             name: name as String?,
             description: description as String?,
@@ -61,11 +62,11 @@ CREATE TABLE IF NOT EXISTS migrations (
 
   @override
   @internal
-  void storeMigrations(List<Migration<String>> migrations) {
-    final withAppliedAt = _db.prepare(
+  void storeMigrations(List<SyncMigration<CommonDatabase, String>> migrations) {
+    final withAppliedAt = db.prepare(
       "INSERT INTO migrations (defined_at, name, description, applied_at, up, down) VALUES (?, ?, ?, ?, ?, ?)",
     );
-    final withoutAppliedAt = _db.prepare(
+    final withoutAppliedAt = db.prepare(
       "INSERT INTO migrations (defined_at, name, description, up, down) VALUES (?, ?, ?, ?, ?)",
     );
 
@@ -96,8 +97,8 @@ CREATE TABLE IF NOT EXISTS migrations (
 
   @override
   @internal
-  void removeMigrations(List<Migration<String>> migrations) {
-    final stmt = _db.prepare('''DELETE FROM migrations WHERE defined_at = ?''');
+  void removeMigrations(List<SyncMigration<CommonDatabase, String>> migrations) {
+    final stmt = db.prepare('''DELETE FROM migrations WHERE defined_at = ?''');
 
     for (final migration in migrations) {
       stmt.execute([migration.definedAt.millisecondsSinceEpoch]);
@@ -109,18 +110,18 @@ CREATE TABLE IF NOT EXISTS migrations (
   @override
   @internal
   void performMigration(String migration) {
-    _db.execute(migration);
+    db.execute(migration);
   }
 
   @override
   @internal
-  void beginTransaction() => transactor.begin(_db);
+  void beginTransaction() => transactor.begin(db);
 
   @override
   @internal
-  void commitTransaction() => transactor.commit(_db);
+  void commitTransaction() => transactor.commit(db);
 
   @override
   @internal
-  void rollbackTransaction() => transactor.rollback(_db);
+  void rollbackTransaction() => transactor.rollback(db);
 }

--- a/packages/sqlite3/lib/src/database.dart
+++ b/packages/sqlite3/lib/src/database.dart
@@ -2,12 +2,20 @@ import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_mul
 import 'package:meta/meta.dart';
 import 'package:sqlite3/common.dart';
 
+import 'transaction.dart';
+
 /// A [SyncDatabase] implementation for SQLite3.
 class Sqlite3Database implements SyncDatabase<String> {
   /// Creates a new [Sqlite3Database] instance.
-  const Sqlite3Database(this._db);
+  const Sqlite3Database(
+    this._db, {
+    this.transactor = const TransactionDelegate(),
+  });
 
   final CommonDatabase _db;
+
+  /// Responsible for handling transactions
+  final Transactor transactor;
 
   @override
   void initializeMigrationsTable() {
@@ -106,19 +114,13 @@ CREATE TABLE IF NOT EXISTS migrations (
 
   @override
   @internal
-  void beginTransaction() {
-    _db.execute('BEGIN TRANSACTION');
-  }
+  void beginTransaction() => transactor.begin(_db);
 
   @override
   @internal
-  void commitTransaction() {
-    _db.execute('COMMIT TRANSACTION');
-  }
+  void commitTransaction() => transactor.commit(_db);
 
   @override
   @internal
-  void rollbackTransaction() {
-    _db.execute('ROLLBACK TRANSACTION');
-  }
+  void rollbackTransaction() => transactor.rollback(_db);
 }

--- a/packages/sqlite3/lib/src/database.dart
+++ b/packages/sqlite3/lib/src/database.dart
@@ -9,7 +9,7 @@ class Sqlite3Database implements SyncDatabase<CommonDatabase, String> {
   /// Creates a new [Sqlite3Database] instance.
   ///
   /// The [connect] function is used to establish a connection to the SQLite3 database,
-  /// see [CommonDatabase.reconnect].
+  /// see [Sqlite3Database.reconnect].
   Sqlite3Database(
     CommonDatabase Function(CommonDatabase? oldConnection) connect, {
     this.transactor = const TransactionDelegate(),

--- a/packages/sqlite3/lib/src/database.dart
+++ b/packages/sqlite3/lib/src/database.dart
@@ -1,4 +1,5 @@
 import 'package:db_migrations_with_multiverse_time_travel/db_migrations_with_multiverse_time_travel.dart';
+import 'package:meta/meta.dart';
 import 'package:sqlite3/common.dart';
 
 /// A [SyncDatabase] implementation for SQLite3.
@@ -30,6 +31,7 @@ CREATE TABLE IF NOT EXISTS migrations (
   }
 
   @override
+  @internal
   Iterator<Migration<String>> retrieveAllMigrations() {
     return _db
         .select('''SELECT * FROM migrations ORDER BY defined_at ASC''')
@@ -50,6 +52,7 @@ CREATE TABLE IF NOT EXISTS migrations (
   }
 
   @override
+  @internal
   void storeMigrations(List<Migration<String>> migrations) {
     final withAppliedAt = _db.prepare(
       "INSERT INTO migrations (defined_at, name, description, applied_at, up, down) VALUES (?, ?, ?, ?, ?, ?)",
@@ -84,6 +87,7 @@ CREATE TABLE IF NOT EXISTS migrations (
   }
 
   @override
+  @internal
   void removeMigrations(List<Migration<String>> migrations) {
     final stmt = _db.prepare('''DELETE FROM migrations WHERE defined_at = ?''');
 
@@ -95,21 +99,25 @@ CREATE TABLE IF NOT EXISTS migrations (
   }
 
   @override
+  @internal
   void performMigration(String migration) {
     _db.execute(migration);
   }
 
   @override
+  @internal
   void beginTransaction() {
     _db.execute('BEGIN TRANSACTION');
   }
 
   @override
+  @internal
   void commitTransaction() {
     _db.execute('COMMIT TRANSACTION');
   }
 
   @override
+  @internal
   void rollbackTransaction() {
     _db.execute('ROLLBACK TRANSACTION');
   }

--- a/packages/sqlite3/lib/src/transaction.dart
+++ b/packages/sqlite3/lib/src/transaction.dart
@@ -63,9 +63,9 @@ class BackupTransactionDelegate extends Transactor {
 
   /// The name of the backup file that will be created in the same directory as the database file.
   final String backupFileName;
-  late final String _path;
-  late final File _dbFile;
-  late final File _backupFile;
+  late String _path;
+  late File _dbFile;
+  late File _backupFile;
 
   @override
   void begin(Sqlite3Database db) {

--- a/packages/sqlite3/lib/src/transaction.dart
+++ b/packages/sqlite3/lib/src/transaction.dart
@@ -87,7 +87,7 @@ class BackupTransactionDelegate extends Transactor {
   @override
   void rollback(CommonDatabase db) {
     db.dispose();
-    if (_path.isEmpty ||_path == ':memory:') return;
+    if (_path.isEmpty || _path == ':memory:') return;
     _backupFile.renameSync(_dbFile.path);
   }
 }

--- a/packages/sqlite3/lib/src/transaction.dart
+++ b/packages/sqlite3/lib/src/transaction.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:sqlite3/common.dart';
 import 'database.dart';
 
 /// A delegate for handling database transactions.

--- a/packages/sqlite3/lib/src/transaction.dart
+++ b/packages/sqlite3/lib/src/transaction.dart
@@ -89,5 +89,6 @@ class BackupTransactionDelegate extends Transactor {
     db.dispose();
     if (_path == ':memory:') return;
     _backupFile.copySync(_dbFile.path);
+    _backupFile.deleteSync();
   }
 }

--- a/packages/sqlite3/lib/src/transaction.dart
+++ b/packages/sqlite3/lib/src/transaction.dart
@@ -71,10 +71,11 @@ class BackupTransactionDelegate extends Transactor {
   void begin(CommonDatabase db) {
     _path = db.select("select file from pragma_database_list where name = 'main'").first.values.first! as String;
     if (_path.isEmpty || _path == ':memory:') {
-      db.execute("VACUUM INTO '$backupFileName';");
+      _backupFile = File(backupFileName);
+    } else {
+      _dbFile = File(_path);
+      _backupFile = File('${_dbFile.parent.path}/$backupFileName');
     }
-    _dbFile = File(_path);
-    _backupFile = File('${_dbFile.parent.path}/$backupFileName');
     if (_backupFile.existsSync()) {
       _backupFile.deleteSync();
     }

--- a/packages/sqlite3/lib/src/transaction.dart
+++ b/packages/sqlite3/lib/src/transaction.dart
@@ -88,7 +88,6 @@ class BackupTransactionDelegate extends Transactor {
   void rollback(CommonDatabase db) {
     db.dispose();
     if (_path == ':memory:') return;
-    _backupFile.copySync(_dbFile.path);
-    _backupFile.deleteSync();
+    _backupFile.renameSync(_dbFile.path);
   }
 }

--- a/packages/sqlite3/lib/src/transaction.dart
+++ b/packages/sqlite3/lib/src/transaction.dart
@@ -87,7 +87,7 @@ class BackupTransactionDelegate extends Transactor {
   @override
   void rollback(CommonDatabase db) {
     db.dispose();
-    if (_path == ':memory:') return;
+    if (_path.isEmpty ||_path == ':memory:') return;
     _backupFile.renameSync(_dbFile.path);
   }
 }

--- a/packages/sqlite3/pubspec.yaml
+++ b/packages/sqlite3/pubspec.yaml
@@ -15,7 +15,7 @@ resolution: workspace
 # Add regular dependencies here.
 dependencies:
   db_migrations_with_multiverse_time_travel: ^1.0.1
-  meta: ^1.17.0
+  meta: ^1.3.0
   sqlite3: ^2.0.0
 
 dev_dependencies:

--- a/packages/sqlite3/pubspec.yaml
+++ b/packages/sqlite3/pubspec.yaml
@@ -15,6 +15,7 @@ resolution: workspace
 # Add regular dependencies here.
 dependencies:
   db_migrations_with_multiverse_time_travel: ^1.0.1
+  meta: ^1.17.0
   sqlite3: ^2.0.0
 
 dev_dependencies:

--- a/packages/sqlite3/pubspec.yaml
+++ b/packages/sqlite3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite3_migrations_with_multiverse_time_travel
 description: Runs database migrations for apps using sqlite3. Check out different branches during development without having to reset the db.
-version: 1.0.2
+version: 2.0.0
 repository: https://github.com/benthillerkus/db_migrations_with_multiverse_time_travel
 issue_tracker: https://github.com/benthillerkus/db_migrations_with_multiverse_time_travel/issues
 topics: ["database", "migration", "sqlite"]
@@ -14,7 +14,7 @@ resolution: workspace
 
 # Add regular dependencies here.
 dependencies:
-  db_migrations_with_multiverse_time_travel: ^1.0.1
+  db_migrations_with_multiverse_time_travel: ^2.0.0
   meta: ^1.3.0
   sqlite3: ^2.0.0
 

--- a/packages/sqlite3/test/integration_test.dart
+++ b/packages/sqlite3/test/integration_test.dart
@@ -49,7 +49,7 @@ void main() {
 
     log.info("In development the app is now started and the migrations are applied");
     {
-      Sqlite3Database(db).migrate(migrationsMain);
+      Sqlite3Database((_) => db).migrate(migrationsMain);
 
       expect(
         db.select("select * from sqlite_master where type='table' and name='users' limit 1"),
@@ -67,7 +67,7 @@ void main() {
 
       expect(users, ['Alice', 'Bob', 'Steward', 'Mallory']);
 
-      expect(Sqlite3Database(db).retrieveAllMigrations().toList(), migrationsMain);
+      expect(Sqlite3Database((_) => db).retrieveAllMigrations().toList(), migrationsMain);
     }
 
     log.info("On a branch we now add posts as a feature");
@@ -92,7 +92,7 @@ void main() {
       ),
     ];
     {
-      Sqlite3Database(db).migrate(migrationsBranchPosts);
+      Sqlite3Database((_) => db).migrate(migrationsBranchPosts);
 
       expect(
         db.select("select * from sqlite_master where type='table' and name='posts' limit 1"),
@@ -102,7 +102,7 @@ void main() {
 
       db.execute("insert into posts (user_id, content) values (1, 'Hello, World!'), (2, 'Hi!');");
 
-      expect(Sqlite3Database(db).retrieveAllMigrations().toList(), migrationsBranchPosts);
+      expect(Sqlite3Database((_) => db).retrieveAllMigrations().toList(), migrationsBranchPosts);
     }
 
     log.info("On a different branch we want to rename users.identifier to users.id");
@@ -116,7 +116,7 @@ void main() {
       ),
     ];
     {
-      Sqlite3Database(db).migrate(migrationsBranchRenameIdentifier);
+      Sqlite3Database((_) => db).migrate(migrationsBranchRenameIdentifier);
 
       expect(
         db.select("select * from sqlite_master where type='table' and name='users' limit 1"),
@@ -131,7 +131,7 @@ void main() {
       expect(db.select("select id from users"), isNotEmpty);
 
       expect(
-        Sqlite3Database(db).retrieveAllMigrations().toList(),
+        Sqlite3Database((_) => db).retrieveAllMigrations().toList(),
         migrationsBranchRenameIdentifier,
       );
     }
@@ -148,7 +148,7 @@ void main() {
         ),
       ];
 
-      Sqlite3Database(db).migrate(migrationsBranchLikes);
+      Sqlite3Database((_) => db).migrate(migrationsBranchLikes);
 
       log.info("The app is now running on the likes branch");
       db.execute("insert into posts (user_id, content) values (1, 'Hello, World!'), (2, 'Hi!');");
@@ -165,7 +165,7 @@ void main() {
         ['Hi!', 0],
       ]);
 
-      expect(Sqlite3Database(db).retrieveAllMigrations().toList(), migrationsBranchLikes);
+      expect(Sqlite3Database((_) => db).retrieveAllMigrations().toList(), migrationsBranchLikes);
     }
 
     log.info("Now the rename branch has been merged into main");
@@ -174,7 +174,7 @@ void main() {
 
     log.info("We check out main");
     {
-      Sqlite3Database(db).migrate(migrationsMain);
+      Sqlite3Database((_) => db).migrate(migrationsMain);
 
       expect(
         db.select("select * from sqlite_master where type='table' and name='users' limit 1"),
@@ -188,7 +188,7 @@ void main() {
 
       expect(db.select("select id from users"), isNotEmpty);
 
-      expect(Sqlite3Database(db).retrieveAllMigrations().toList(), migrationsMain);
+      expect(Sqlite3Database((_) => db).retrieveAllMigrations().toList(), migrationsMain);
     }
 
     log.info("Now we have to update our posts branch to include the changes from the main branch");
@@ -210,7 +210,7 @@ void main() {
 
     log.info("And we open the app on the posts branch");
     {
-      Sqlite3Database(db).migrate(migrationsBranchPostsUpdated);
+      Sqlite3Database((_) => db).migrate(migrationsBranchPostsUpdated);
 
       expect(
         db.select("select * from sqlite_master where type='table' and name='posts' limit 1"),
@@ -220,7 +220,7 @@ void main() {
 
       db.execute("insert into posts (user_id, content) values (1, 'Hello, World!'), (2, 'Hi!');");
 
-      expect(Sqlite3Database(db).retrieveAllMigrations().toList(), migrationsBranchPostsUpdated);
+      expect(Sqlite3Database((_) => db).retrieveAllMigrations().toList(), migrationsBranchPostsUpdated);
     }
 
     log.info("Now we merge the posts branch into main");
@@ -228,7 +228,7 @@ void main() {
     migrationsMain.addAll(migrationsBranchPostsUpdated);
     log.info("We check out main");
     {
-      Sqlite3Database(db).migrate(migrationsMain);
+      Sqlite3Database((_) => db).migrate(migrationsMain);
 
       expect(
         db.select("select * from sqlite_master where type='table' and name='users' limit 1"),
@@ -246,7 +246,7 @@ void main() {
         reason: "because we added sample data on the posts 'branch', before we merged on main",
       );
 
-      expect(Sqlite3Database(db).retrieveAllMigrations().toList(), migrationsMain);
+      expect(Sqlite3Database((_) => db).retrieveAllMigrations().toList(), migrationsMain);
     }
 
     log.info("Now we merge main into the likes branch, to prepare it for merging into main");
@@ -258,7 +258,7 @@ void main() {
     {
       log.info("would end up throwing an error");
       expect(
-        () => Sqlite3Database(db).migrate([
+        () => Sqlite3Database((_) => db).migrate([
           ...migrationsMain,
           Migration(
             name: "add likes column to posts",
@@ -297,7 +297,7 @@ void main() {
       ].sorted((a, b) => a.compareTo(b));
       expect(sorted.first < sorted.last, isTrue);
       expect(
-        () => Sqlite3Database(db).migrate(sorted),
+        () => Sqlite3Database((_) => db).migrate(sorted),
         throwsA(
           isA<SqliteException>().having((e) => e.message, "message", contains("no such table")),
         ),
@@ -316,13 +316,13 @@ void main() {
         ),
       ];
 
-      Sqlite3Database(db).migrate(migrationsBranchLikesUpdated);
+      Sqlite3Database((_) => db).migrate(migrationsBranchLikesUpdated);
 
       expect(
         db.select("select name from pragma_table_info('posts')").map((row) => row.values.first),
         ["id", "user_id", "content", "created_at", "likes"],
       );
-      expect(Sqlite3Database(db).retrieveAllMigrations().toList(), migrationsBranchLikesUpdated);
+      expect(Sqlite3Database((_) => db).retrieveAllMigrations().toList(), migrationsBranchLikesUpdated);
     }
   });
 }

--- a/packages/sqlite3/test/transactor_test.dart
+++ b/packages/sqlite3/test/transactor_test.dart
@@ -1,0 +1,78 @@
+import 'dart:ffi';
+
+import 'package:file/local.dart';
+import 'package:sqlite3/open.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:sqlite3_migrations_with_multiverse_time_travel/sqlite3_migrations_with_multiverse_time_travel.dart';
+import 'package:sqlite3_test/sqlite3_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Database db;
+  late Sqlite3Database wrapper;
+  late TestSqliteFileSystem vfs;
+
+  setUpAll(() {
+    open.overrideFor(OperatingSystem.windows, () => DynamicLibrary.open('winsqlite3.dll'));
+    vfs = TestSqliteFileSystem(fs: const LocalFileSystem());
+    sqlite3.registerVirtualFileSystem(vfs);
+  });
+
+  tearDownAll(() {
+    sqlite3.unregisterVirtualFileSystem(vfs);
+  });
+
+  final migrations = [
+    Migration(
+      definedAt: DateTime.utc(2021, 1, 1),
+      up: 'CREATE TABLE tbl (a TEXT)',
+      down: 'DROP TABLE tbl',
+    ),
+    Migration(
+      definedAt: DateTime.utc(2021, 1, 2),
+      up: 'not valid SQL',
+      down: 'DROP TABLE tbl2',
+    ),
+  ];
+
+  test("Transaction", () {
+    db = sqlite3.openInMemory(vfs: vfs.name);
+    wrapper = Sqlite3Database(db);
+    addTearDown(db.dispose);
+
+    expect(() => wrapper.migrate(migrations), throwsA(isA<SqliteException>()));
+
+    // Transaction should rollback, so the tbl table should not exist
+    final result = db.select("SELECT name FROM sqlite_master WHERE type = 'table' and name = 'tbl'");
+    expect(result, isEmpty);
+  });
+
+  test("NoTransaction", () {
+    db = sqlite3.openInMemory(vfs: vfs.name);
+    wrapper = Sqlite3Database(db, transactor: const NoTransactionDelegate());
+    addTearDown(db.dispose);
+
+    expect(() => wrapper.migrate(migrations), throwsA(isA<SqliteException>()));
+
+    // No transaction cannot do any rollback, so the tbl table should exist
+    final result = db.select("SELECT name FROM sqlite_master WHERE type = 'table' and name = 'tbl'");
+    expect(result, isNotEmpty);
+  });
+
+  test("BackupTransaction", retry: 3, () {
+    if (vfs.xAccess("test.db", 0) == 1) {
+      vfs.xDelete("test.db", 1);
+    }
+    db = sqlite3.open("test.db", vfs: vfs.name);
+    wrapper = Sqlite3Database(db, transactor: BackupTransactionDelegate());
+    addTearDown(() {
+      db.dispose();
+      vfs.xDelete("test.db", 1);
+    });
+    expect(() => wrapper.migrate(migrations), throwsA(isA<SqliteException>()));
+    db = sqlite3.open("test.db", vfs: vfs.name);
+    // Backup transaction should rollback, so the tbl table should not exist
+    final result = db.select("SELECT name FROM sqlite_master WHERE type = 'table' and name = 'tbl'");
+    expect(result, isEmpty);
+  });
+}

--- a/packages/sqlite3/test/transactor_test.dart
+++ b/packages/sqlite3/test/transactor_test.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi';
+import 'dart:io';
 
 import 'package:file/local.dart';
 import 'package:logging/logging.dart';
@@ -65,17 +66,17 @@ void main() {
   });
 
   test("BackupTransaction", retry: 3, () {
-    if (vfs.xAccess("test.db", 0) == 1) {
-      vfs.xDelete("test.db", 1);
+    if (File("test.db").existsSync()) {
+      File("test.db").deleteSync();
     }
-    db = sqlite3.open("test.db", vfs: vfs.name);
+    db = sqlite3.open("test.db");
     wrapper = Sqlite3Database(db, transactor: BackupTransactionDelegate());
     addTearDown(() {
       db.dispose();
-      vfs.xDelete("test.db", 1);
+      File("test.db").deleteSync();
     });
     expect(() => wrapper.migrate(migrations), throwsA(isA<SqliteException>()));
-    db = sqlite3.open("test.db", vfs: vfs.name);
+    db = sqlite3.open("test.db");
     // Backup transaction should rollback, so the tbl table should not exist
     final result = db.select("SELECT name FROM sqlite_master WHERE type = 'table' and name = 'tbl'");
     expect(result, isEmpty);

--- a/packages/sqlite3/test/transactor_test.dart
+++ b/packages/sqlite3/test/transactor_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ffi';
 
 import 'package:file/local.dart';
+import 'package:logging/logging.dart';
 import 'package:sqlite3/open.dart';
 import 'package:sqlite3/sqlite3.dart';
 import 'package:sqlite3_migrations_with_multiverse_time_travel/sqlite3_migrations_with_multiverse_time_travel.dart';
@@ -16,6 +17,10 @@ void main() {
     open.overrideFor(OperatingSystem.windows, () => DynamicLibrary.open('winsqlite3.dll'));
     vfs = TestSqliteFileSystem(fs: const LocalFileSystem());
     sqlite3.registerVirtualFileSystem(vfs);
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen((record) {
+      print('${record.level.name}: ${record.time}: ${record.message}');
+    });
   });
 
   tearDownAll(() {

--- a/packages/sqlite3/test/wrapper_test.dart
+++ b/packages/sqlite3/test/wrapper_test.dart
@@ -49,7 +49,7 @@ void main() {
 
     group('Insert migration', () {
       test('Insertion', () {
-        final migration = Migration<String>(
+        final migration = Migration(
           definedAt: DateTime.utc(2021, 1, 1),
           name: 'test',
           description: 'test',
@@ -73,7 +73,7 @@ void main() {
         final moonLanding = DateTime.utc(1969, 7, 20, 20, 18, 04);
         FakeAsync(initialTime: moonLanding).run((_) {
           wrapper.storeMigrations([
-            Migration<String>(
+            Migration(
               definedAt: DateTime.utc(1902, 1, 1),
               up: 'CREATE TABLE tbl (a TEXT)',
               down: 'DROP TABLE tbl',

--- a/packages/sqlite3/test/wrapper_test.dart
+++ b/packages/sqlite3/test/wrapper_test.dart
@@ -25,7 +25,7 @@ void main() {
 
   setUp(() {
     db = sqlite3.openInMemory(vfs: vfs.name);
-    wrapper = Sqlite3Database(db);
+    wrapper = Sqlite3Database((_) => db);
   });
 
   tearDown(() {


### PR DESCRIPTION
- Add flag for Migrations to be always applied (required because `foreign_keys` is per session)
- Add different modes for managing transactions (required because setting `foreign_keys` is a noop inside of a regular transaction)
- Breaking Refactor: Reexport Migration<String> as Migration in integration packages to simplify the API
- Marks some methods on integrations as @internal